### PR TITLE
Use ephemeral port for the TsaasServer in unit tests.

### DIFF
--- a/plugin/src/main/java/org/opennms/plugins/cloud/tsaas/TsaasConfig.java
+++ b/plugin/src/main/java/org/opennms/plugins/cloud/tsaas/TsaasConfig.java
@@ -91,6 +91,17 @@ public class TsaasConfig {
     return this.maxBatchWaitTimeInMilliSeconds;
   }
 
+  public Builder cloneIntoBuilder() {
+    return new Builder()
+            .host(host)
+            .port(port)
+            .tokenKey(tokenKey)
+            .tokenValue(tokenValue)
+            .mtlsEnabled(mtlsEnabled)
+            .batchSize(batchSize)
+            .maxBatchWaitTimeInMilliSeconds(maxBatchWaitTimeInMilliSeconds);
+  }
+
   public static Builder builder() {
     return new Builder();
   }

--- a/plugin/src/test/java/org/opennms/plugins/cloud/tsaas/CloudHealthCheckTest.java
+++ b/plugin/src/test/java/org/opennms/plugins/cloud/tsaas/CloudHealthCheckTest.java
@@ -50,12 +50,17 @@ public class CloudHealthCheckTest {
 
     @Before
     public void setUp() throws Exception {
-        TsaasConfig config = TsaasConfig.builder()
+        TsaasConfig serverConfig = TsaasConfig.builder()
                 .batchSize(1) // set to 1 so that samples are not held back in the queue
+                .port(0)
                 .build();
-        storage = new TsaasStorage(config, mock(SecureCredentialsVault.class));
-        server = new TsaasServer(config, new TsassServerInterceptor(), new InMemoryStorage());
+
+        server = new TsaasServer(serverConfig, new TsassServerInterceptor(), new InMemoryStorage());
         server.startServer();
+
+        TsaasConfig clientConfig = server.getConfig();
+
+        storage = new TsaasStorage(clientConfig, mock(SecureCredentialsVault.class));
     }
 
     @After

--- a/plugin/src/test/java/org/opennms/plugins/cloud/tsaas/TsaasStorageNetworkProblemTest.java
+++ b/plugin/src/test/java/org/opennms/plugins/cloud/tsaas/TsaasStorageNetworkProblemTest.java
@@ -63,14 +63,20 @@ public class TsaasStorageNetworkProblemTest {
 
   private TsaasServer server;
   private TimeSeriesStorage serverStorage;
+  private TsaasConfig clientConfig;
 
   @Before
   public void setUp() throws Exception {
-    TsaasConfig config = TsaasConfig.builder()
-        .build();
+    TsaasConfig serverConfig = TsaasConfig.builder()
+            .port(0)
+            .batchSize(1)
+            .build();
+
     serverStorage = Mockito.mock(TimeSeriesStorage.class);
-    server = new TsaasServer(config, new TsassServerInterceptor(), serverStorage);
+    server = new TsaasServer(serverConfig, new TsassServerInterceptor(), serverStorage);
     server.startServer();
+
+    clientConfig = server.getConfig();
   }
 
   @After
@@ -82,11 +88,7 @@ public class TsaasStorageNetworkProblemTest {
 
   @Test
   public void shouldRecoverAfterServerFailure() throws StorageException, InterruptedException {
-    TsaasConfig config = TsaasConfig
-        .builder()
-        .batchSize(1)
-        .build();
-    TsaasStorage plugin = new TsaasStorage(config, mock(SecureCredentialsVault.class));
+    TsaasStorage plugin = new TsaasStorage(clientConfig, mock(SecureCredentialsVault.class));
 
     plugin.store(createSamples());
     verify(serverStorage, times(1)).store(any());
@@ -105,11 +107,7 @@ public class TsaasStorageNetworkProblemTest {
 
   @Test
   public void shouldRecoverAfterServerException() throws StorageException, InterruptedException {
-    TsaasConfig config = TsaasConfig
-            .builder()
-            .batchSize(1)
-            .build();
-    TsaasStorage plugin = new TsaasStorage(config, mock(SecureCredentialsVault.class));
+    TsaasStorage plugin = new TsaasStorage(clientConfig, mock(SecureCredentialsVault.class));
 
     doThrow(new StorageException("hups")).when(serverStorage).store(any());
     plugin.store(createSamples()); // nothing should happen since this is a non recoverable exception

--- a/plugin/src/test/java/org/opennms/plugins/cloud/tsaas/TsaasStorageTest.java
+++ b/plugin/src/test/java/org/opennms/plugins/cloud/tsaas/TsaasStorageTest.java
@@ -48,12 +48,17 @@ public class TsaasStorageTest extends AbstractStorageIntegrationTest {
 
   @Before
   public void setUp() throws Exception {
-    TsaasConfig config = TsaasConfig.builder()
-        .batchSize(1) // set to 1 so that samples are not held back in the queue
-        .build();
-    storage = new TsaasStorage(config, mock(SecureCredentialsVault.class));
-    server = new TsaasServer(config, new TsassServerInterceptor(), new InMemoryStorage());
+    TsaasConfig serverConfig = TsaasConfig.builder()
+            .batchSize(1) // set to 1 so that samples are not held back in the queue
+            .port(0)
+            .build();
+
+    server = new TsaasServer(serverConfig, new TsassServerInterceptor(), new InMemoryStorage());
     server.startServer();
+
+    TsaasConfig clientConfig = server.getConfig();
+
+    storage = new TsaasStorage(clientConfig, mock(SecureCredentialsVault.class));
     super.setUp();
   }
 

--- a/plugin/src/test/java/org/opennms/plugins/cloud/tsaas/TsaasStorageWithMtlsTest.java
+++ b/plugin/src/test/java/org/opennms/plugins/cloud/tsaas/TsaasStorageWithMtlsTest.java
@@ -62,10 +62,16 @@ public class TsaasStorageWithMtlsTest extends AbstractStorageIntegrationTest {
 
   @Before
   public void setUp() throws Exception {
-    TsaasConfig config = TsaasConfig.builder()
+    TsaasConfig serverConfig = TsaasConfig.builder()
         .mtlsEnabled(true)
         .batchSize(1) // set to 1 so that samples are not held back in the queue
+        .port(0)
         .build();
+
+    server = new TsaasServer(serverConfig, new TsassServerInterceptor(), new InMemoryStorage());
+    server.startServer();
+
+    TsaasConfig clientConfig = server.getConfig();
 
     Path pathToZipFile = Path.of("src/test/resources/cert/cloud-credentials.zip");
     assertTrue(Files.exists(pathToZipFile));
@@ -79,9 +85,7 @@ public class TsaasStorageWithMtlsTest extends AbstractStorageIntegrationTest {
     SecureCredentialsVault scv = mock(SecureCredentialsVault.class);
     when(scv.getCredentials(SCV_ALIAS)).thenReturn(new ImmutableCredentials("", "", attributes));
 
-    storage = new TsaasStorage(config, scv);
-    server = new TsaasServer(config, new TsassServerInterceptor(), new InMemoryStorage());
-    server.startServer();
+    storage = new TsaasStorage(clientConfig, scv);
     super.setUp();
   }
 

--- a/plugin/src/test/java/org/opennms/plugins/cloud/tsaas/testserver/TsaasServer.java
+++ b/plugin/src/test/java/org/opennms/plugins/cloud/tsaas/testserver/TsaasServer.java
@@ -53,7 +53,7 @@ public class TsaasServer {
 
     private static final Logger LOG = LoggerFactory.getLogger(TsaasServer.class);
 
-    private final TsaasConfig config;
+    private TsaasConfig config;
     private Server server;
     private final TimeseriesGrpcImpl timeseriesService;
     private final TsassServerInterceptor serverInterceptor;
@@ -89,7 +89,11 @@ public class TsaasServer {
                 .build()
                 .start();
 
-            LOG.info("Grpc Server started, listening on {}", config.getPort());
+            LOG.info("Grpc Server started, listening on {}", server.getPort());
+            if (server.getPort() != config.getPort()) {
+                LOG.info("saving port {} into config", server.getPort());
+                config = config.cloneIntoBuilder().port(server.getPort()).build();
+            }
             CompletableFuture.runAsync(() -> {
                 try {
                     server.awaitTermination();
@@ -112,4 +116,5 @@ public class TsaasServer {
         LOG.info("Grpc Server stopped");
     }
 
+    public TsaasConfig getConfig() { return config; }
 }

--- a/plugin/src/test/resources/log4j2.xml
+++ b/plugin/src/test/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="error">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>


### PR DESCRIPTION
This lets me compile the plugin normally while also having TSaaS components running.

Set the port in the TsaasConfig to 0 to use an ephemeral port.

If the configured port != the server's actual port once started,
TsaasServer will update its config with the new port number. This
will ensure the same port number is used if the server is stopped
and restarted (this happens in TsaasStorageNetworkProblemTest's
shouldRecoverAfterServerFailure test). The new getConfig() method
can be used to get the (possibly updated) config and is suitable
for clients to use so they connect to the server's ephemeral port.

Added log4j2.xml for tests. This makes it easy to crank up the
log level to see more detail when running tests.