### PR TITLE
DC-291: Fix a compilation problem with newer JDKs and upgrade maven-enforcer-plugin 3.1.0 so failure happens consistently

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,7 @@ jobs:
       - run:
           name: Compile source without tests
           command: |
+            mvn -version
             mvn -DskipITs=true -DskipTests=true -Dbuild.packages clean install
       - save_cache:
           paths:

--- a/karaf-features/pom.xml
+++ b/karaf-features/pom.xml
@@ -109,6 +109,10 @@
                     <groupId>org.glassfish.jaxb</groupId><!-- to satisfy maven-enforcer-plugin -->
                     <artifactId>jaxb-runtime</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId><!-- to satisfy maven-enforcer-plugin -->
+                    <artifactId>log4j-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -125,6 +129,10 @@
                 <exclusion>
                     <groupId>com.google.guava</groupId><!-- to satisfy maven-enforcer-plugin -->
                     <artifactId>guava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId><!-- to satisfy maven-enforcer-plugin -->
+                    <artifactId>log4j-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.4.1</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>enforce</id>


### PR DESCRIPTION
This PR upgrades maven-enforcer-plugin to 3.1.0 so that the `RequireUpperBoundDeps` check issue noted in https://issues.opennms.org/browse/DC-291 fails consistently. It also makes a minor tweak to `ConfigZipExtractor` to build with newer JDKs.

Now, when we run `mvn install` (or `mvn package`), we consistently see this failure:
```
[ERROR] Rule 0: org.apache.maven.plugins.enforcer.RequireUpperBoundDeps failed with message:
Could not build dependency tree Could not collect dependencies: org.opennms.plugins.cloud:cloud-plugin:jar:1.0.0-SNAPSHOT
```

Patrick correctly pointed out that when you run `mvn -X install`, you see why it failed:
```
Caused by: org.apache.maven.wagon.authorization.AuthorizationException: Authorization failed for https://packages.opennms.com/public/maven/maven/org/apache/logging/log4j/log4j-api-java9/2.13.3/log4j-api-java9-2.13.3.pom 403 Forbidden
```

Previously, we had intermittent failures depending on Maven version (ugh) and it only seemed to happen when running the `package` target, not `install`: https://chat.opennms.com/opennms/pl/81bneg6xrfdbpmgmouy7yanzic

The pre-existing issue from https://issues.opennms.org/browse/DC-291 still exists and is not fixed in this PR.