### PR TITLE
DC-282: fix grpc long pause due to network error

### DIFF
--- a/plugin/src/main/java/org/opennms/plugins/cloud/grpc/GrpcConnection.java
+++ b/plugin/src/main/java/org/opennms/plugins/cloud/grpc/GrpcConnection.java
@@ -74,8 +74,11 @@ public class GrpcConnection<T extends AbstractBlockingStub<T>> {
         } else {
             builder.sslContext(createSslContext(config));
         }
-        // setup message size
-        builder.maxInboundMessageSize(MAX_MESSAGE_SIZE).maxInboundMetadataSize(MAX_MESSAGE_SIZE);
+        // setup message size & keepalive time DC-282
+        builder.maxInboundMessageSize(MAX_MESSAGE_SIZE).maxInboundMetadataSize(MAX_MESSAGE_SIZE)
+                .keepAliveTime(10, TimeUnit.SECONDS)
+                .keepAliveTimeout(5, TimeUnit.SECONDS)
+                .keepAliveWithoutCalls(true);
         managedChannel = builder
                 .compressorRegistry(ZStdCodecRegisterUtil.createCompressorRegistry())
                 .decompressorRegistry(ZStdCodecRegisterUtil.createDecompressorRegistry())


### PR DESCRIPTION
https://issues.opennms.org/browse/DC-282

After few weeks of stability test. It didn't show up anymore after the new keepalive setting. 