### PR TITLE
DC-307: Switch to KVStore

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
   system-test-executor:
     machine:
       # image: ubuntu-2004:202010-01
-      image: ubuntu-2204:2022.07.1
+      image: ubuntu-2004:202111-02
 
 workflows:
   build-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,8 @@ executors:
           MAVEN_OPTS: -Xmx1g
   system-test-executor:
     machine:
-      image: ubuntu-2004:202010-01
+      # image: ubuntu-2004:202010-01
+      image: ubuntu-2204:2022.07.1
 
 workflows:
   build-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,7 @@ executors:
           MAVEN_OPTS: -Xmx1g
   system-test-executor:
     machine:
-      # image: ubuntu-2004:202010-01
-      image: ubuntu-2004:202111-02
+      image: ubuntu-2004:202010-01
 
 workflows:
   build-deploy:

--- a/it-test/src/test/resources/docker-compose.yaml
+++ b/it-test/src/test/resources/docker-compose.yaml
@@ -41,6 +41,7 @@ services:
       - ${USER_HOME}/.m2/repository/org/opennms/tsaas/tsaas-grpc:/opt/opennms/system/org/opennms/tsaas/tsaas-grpc
       - ${USER_HOME}/.m2/repository/com/google/protobuf/protobuf-java/3.19.4:/opt/opennms/system/com/google/protobuf/protobuf-java/3.19.4
       - ${USER_HOME}/.m2/repository/com/github/luben/zstd-jni/1.5.0-2/:/opt/opennms/system/com/github/luben/zstd-jni/1.5.0-2
+      - ${USER_HOME}/.m2/repository/org/json/json/20220924/:/opt/opennms/system/org/json/json/20220924
     command: ["-s"]
     ports:
       - "8101:8101/tcp" # ssh port for karaf console

--- a/it-test/src/test/resources/docker-compose.yaml
+++ b/it-test/src/test/resources/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
       retries: 3
 
   horizon:
-    image: ${DOCKER_REGISTRY:-docker.io}/${DOCKER_ORG:-opennms}/${HORIZON_OCI:-horizon}:${ONMS_VERSION:-30.0.1-SNAPSHOT}
+    image: ${DOCKER_REGISTRY:-docker.io}/${DOCKER_ORG:-opennms}/${HORIZON_OCI:-horizon}:${ONMS_VERSION:-release-30.x}
     hostname: horizon
     sysctls:
       net.ipv4.ping_group_range: "0 429496729"

--- a/it-test/src/test/resources/docker-compose.yaml
+++ b/it-test/src/test/resources/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
       retries: 3
 
   horizon:
-    image: ${DOCKER_REGISTRY:-docker.io}/${DOCKER_ORG:-opennms}/${HORIZON_OCI:-horizon}:${ONMS_VERSION:-release-30.x}
+    image: ${DOCKER_REGISTRY:-docker.io}/${DOCKER_ORG:-opennms}/${HORIZON_OCI:-horizon}:${ONMS_VERSION:-30.0.3-SNAPSHOT}
     hostname: horizon
     sysctls:
       net.ipv4.ping_group_range: "0 429496729"
@@ -43,7 +43,7 @@ services:
       - ${USER_HOME}/.m2/repository/com/github/luben/zstd-jni/1.5.0-2/:/opt/opennms/system/com/github/luben/zstd-jni/1.5.0-2
     command: ["-s"]
     ports:
-      - "8101:8101/tcp" # ssh port for karaf cosole
+      - "8101:8101/tcp" # ssh port for karaf console
       - "8980:8980/tcp" # http port
     healthcheck:
       test: [ "CMD", "curl", "-f", "-I", "http://localhost:8980/opennms/login.jsp" ]

--- a/it-test/src/test/resources/docker-compose.yaml
+++ b/it-test/src/test/resources/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
       retries: 3
 
   horizon:
-    image: ${DOCKER_REGISTRY:-docker.io}/${DOCKER_ORG:-opennms}/${HORIZON_OCI:-horizon}:${ONMS_VERSION:-30.0.2-SNAPSHOT}
+    image: ${DOCKER_REGISTRY:-docker.io}/${DOCKER_ORG:-opennms}/${HORIZON_OCI:-horizon}:${ONMS_VERSION:-30.0.1-SNAPSHOT}
     hostname: horizon
     sysctls:
       net.ipv4.ping_group_range: "0 429496729"

--- a/it-test/src/test/resources/docker-compose.yaml
+++ b/it-test/src/test/resources/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
       retries: 3
 
   horizon:
-    image: ${DOCKER_REGISTRY:-docker.io}/${DOCKER_ORG:-opennms}/${HORIZON_OCI:-horizon}:${ONMS_VERSION:-30.0.3-SNAPSHOT}
+    image: ${DOCKER_REGISTRY:-docker.io}/${DOCKER_ORG:-opennms}/${HORIZON_OCI:-horizon}:${ONMS_VERSION:-30.0.2-SNAPSHOT}
     hostname: horizon
     sysctls:
       net.ipv4.ping_group_range: "0 429496729"

--- a/it-test/src/test/resources/docker-compose.yaml
+++ b/it-test/src/test/resources/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
       retries: 3
 
   horizon:
-    image: ${DOCKER_REGISTRY:-docker.io}/${DOCKER_ORG:-opennms}/${HORIZON_OCI:-horizon}:${ONMS_VERSION:-release-30.x}
+    image: ${DOCKER_REGISTRY:-docker.io}/${DOCKER_ORG:-opennms}/${HORIZON_OCI:-horizon}:${ONMS_VERSION:-30.0.3}
     hostname: horizon
     sysctls:
       net.ipv4.ping_group_range: "0 429496729"

--- a/karaf-features/src/main/resources/features.xml
+++ b/karaf-features/src/main/resources/features.xml
@@ -12,6 +12,7 @@
         <bundle>mvn:org.opennms.plugins.cloud/cloud-plugin/${project.version}</bundle>
         <bundle>mvn:org.opennms.plugins.cloud.wrap/grpc/${project.version}</bundle>
         <bundle>mvn:org.opennms.plugins.cloud.wrap/jwt/${project.version}</bundle>
+        <bundle>mvn:org.json/json/${jsonVersion}</bundle>
     </feature>
     <feature name="cloud-guava" description="guava" version="${project.version}">
         <bundle dependency="true">mvn:com.google.guava/failureaccess/${failureAccessVersion}</bundle>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -213,6 +213,16 @@
             <artifactId>grpc-testing</artifactId>
             <version>${grpcVersion}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>grpc-stub</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>grpc-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -127,6 +127,11 @@
             <artifactId>common</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>${jsonVersion}</version>
+        </dependency>
+        <dependency>
             <groupId>org.opennms.plugins.cloud.wrap</groupId>
             <artifactId>grpc</artifactId>
             <version>${project.version}</version>

--- a/plugin/src/main/java/org/opennms/plugins/cloud/config/CertificateImporter.java
+++ b/plugin/src/main/java/org/opennms/plugins/cloud/config/CertificateImporter.java
@@ -26,7 +26,6 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-
 package org.opennms.plugins.cloud.config;
 
 import java.io.IOException;
@@ -35,7 +34,7 @@ import java.nio.file.Path;
 import java.util.Map;
 import java.util.Objects;
 
-import org.opennms.plugins.cloud.config.SecureCredentialsVaultUtil.Type;
+import org.opennms.plugins.cloud.config.ConfigStore.Key;
 import org.opennms.plugins.cloud.grpc.GrpcConnectionConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,12 +44,12 @@ public class CertificateImporter {
 
     private final String fileParam;
 
-    private final SecureCredentialsVaultUtil scv;
+    private final ConfigStore scv;
 
     private static final Logger LOG = LoggerFactory.getLogger(CertificateImporter.class);
 
     public CertificateImporter(final String fileParam,
-                               final SecureCredentialsVaultUtil scv,
+                               final ConfigStore scv,
                                final GrpcConnectionConfig config) {
         this.fileParam = Objects.requireNonNull(fileParam);
         this.scv = Objects.requireNonNull(scv);
@@ -67,7 +66,7 @@ public class CertificateImporter {
             throw new IllegalArgumentException(String.format("%s is not a readable.", fileParam));
         }
 
-        final Map<Type, String> cloudGatewayConfig = new ConfigZipExtractor(file).getGrpcConnectionConfig();
+        final Map<ConfigStore.Key, String> cloudGatewayConfig = new ConfigZipExtractor(file).getGrpcConnectionConfig();
         scv.putProperties(cloudGatewayConfig);
         LOG.info("Imported certificates from {}", fileParam);
 
@@ -80,9 +79,9 @@ public class CertificateImporter {
         }
     }
 
-    public boolean isConfigStored(final Map<Type, String> config) {
-        return Objects.equals(config.get(Type.privatekey), scv.getOrNull(Type.privatekey))
-                && Objects.equals(config.get(Type.publickey), scv.getOrNull(Type.publickey))
-                && Objects.equals(config.get(Type.tokenvalue), scv.getOrNull(Type.tokenvalue));
+    public boolean isConfigStored(final Map<Key, String> config) {
+        return Objects.equals(config.get(ConfigStore.Key.privatekey), scv.getOrNull(ConfigStore.Key.privatekey))
+                && Objects.equals(config.get(Key.publickey), scv.getOrNull(ConfigStore.Key.publickey))
+                && Objects.equals(config.get(Key.tokenvalue), scv.getOrNull(Key.tokenvalue));
     }
 }

--- a/plugin/src/main/java/org/opennms/plugins/cloud/config/ConfigStore.java
+++ b/plugin/src/main/java/org/opennms/plugins/cloud/config/ConfigStore.java
@@ -36,8 +36,8 @@ import java.util.Optional;
  * Makes the accessing properties easier.
  */
 public interface ConfigStore {
-  public static final String SCV_ALIAS = "plugin.cloud";
-  public final static String TOKEN_KEY = "token";
+  String STORE_PREFIX = "plugin.cloud";
+  String TOKEN_KEY = "token";
 
   /**
    * All enums must be lower case.

--- a/plugin/src/main/java/org/opennms/plugins/cloud/config/ConfigStore.java
+++ b/plugin/src/main/java/org/opennms/plugins/cloud/config/ConfigStore.java
@@ -43,7 +43,7 @@ public interface ConfigStore {
    * All enums must be lower case.
    * Otherwise scv won't save them correctly.
    */
-  @SuppressWarnings("java:S115")
+  @SuppressWarnings("java:S115") // we don't want to be warned about lower case
   enum Key {
     truststore, publickey, privatekey, tokenkey, tokenvalue, grpchost, grpcport,
     activeservices,

--- a/plugin/src/main/java/org/opennms/plugins/cloud/config/ConfigStore.java
+++ b/plugin/src/main/java/org/opennms/plugins/cloud/config/ConfigStore.java
@@ -43,6 +43,7 @@ public interface ConfigStore {
    * All enums must be lower case.
    * Otherwise scv won't save them correctly.
    */
+  @SuppressWarnings("java:S115")
   enum Key {
     truststore, publickey, privatekey, tokenkey, tokenvalue, grpchost, grpcport,
     activeservices,

--- a/plugin/src/main/java/org/opennms/plugins/cloud/config/ConfigZipExtractor.java
+++ b/plugin/src/main/java/org/opennms/plugins/cloud/config/ConfigZipExtractor.java
@@ -40,7 +40,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 
-import org.opennms.plugins.cloud.config.SecureCredentialsVaultUtil.Type;
+import org.opennms.plugins.cloud.config.ConfigStore.Key;
 
 /**
  * The Zip file looks like this:
@@ -62,18 +62,18 @@ public class ConfigZipExtractor {
         }
     }
 
-    public Map<Type, String> getGrpcConnectionConfig() throws IOException {
-        Map<Type, String> properties = new EnumMap<>(Type.class);
+    public Map<ConfigStore.Key, String> getGrpcConnectionConfig() throws IOException {
+        Map<ConfigStore.Key, String> properties = new EnumMap<>(ConfigStore.Key.class);
         Map<String, String> configFromZip = getConfig();
-        for(Type type : Type.values()) {
+        for(Key type : ConfigStore.Key.values()) {
             String value = configFromZip.get(type.name());
             if(value != null) {
                 properties.put(type, value);
             }
         }
-        properties.put(Type.publickey, getPublicKey());
-        properties.put(Type.privatekey, getPrivateKey());
-        properties.put(Type.tokenvalue, getJwtToken());
+        properties.put(ConfigStore.Key.publickey, getPublicKey());
+        properties.put(Key.privatekey, getPrivateKey());
+        properties.put(ConfigStore.Key.tokenvalue, getJwtToken());
         return properties;
     }
 

--- a/plugin/src/main/java/org/opennms/plugins/cloud/config/Housekeeper.java
+++ b/plugin/src/main/java/org/opennms/plugins/cloud/config/Housekeeper.java
@@ -29,12 +29,22 @@
 package org.opennms.plugins.cloud.config;
 
 import static java.time.temporal.ChronoUnit.DAYS;
+import static org.opennms.integration.api.v1.runtime.Container.OPENNMS;
+import static org.opennms.integration.api.v1.runtime.Container.SENTINEL;
+import static org.opennms.plugins.cloud.config.ConfigStore.Key.grpchost;
+import static org.opennms.plugins.cloud.config.ConfigStore.Key.grpcport;
+import static org.opennms.plugins.cloud.config.ConfigStore.Key.privatekey;
+import static org.opennms.plugins.cloud.config.ConfigStore.Key.publickey;
 
 import java.security.cert.CertificateException;
 import java.time.Instant;
+import java.util.Objects;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+
+import org.opennms.integration.api.v1.runtime.RuntimeInfo;
+import org.opennms.plugins.cloud.grpc.GrpcConnectionConfig;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -47,29 +57,61 @@ public class Housekeeper {
     private final ScheduledExecutorService executor;
     private final int intervalInSecondsForToken;
     private final int intervalInSecondsForCert;
+    private final int intervalForSyncInSeconds;
 
     private final ConfigurationManager configurationManager;
+    private final ConfigStore config;
+
+    private final RuntimeInfo runtimeInfo;
+    private GrpcConnectionConfig currentConfig;
 
     public Housekeeper(final ConfigurationManager configurationManager,
+                       final ConfigStore config,
+                       final RuntimeInfo runtimeInfo,
                        final int intervalInSecondsForToken,
-                       final int intervalInSecondsForCert) {
+                       final int intervalInSecondsForCert,
+                       final int intervalForSyncInSeconds) {
         this.configurationManager = configurationManager;
+        this.config = Objects.requireNonNull(config);
+        this.runtimeInfo = Objects.requireNonNull(runtimeInfo);
         executor = Executors.newSingleThreadScheduledExecutor();
         this.intervalInSecondsForToken = intervalInSecondsForToken;
         this.intervalInSecondsForCert = intervalInSecondsForCert;
+        this.intervalForSyncInSeconds = intervalForSyncInSeconds;
     }
 
-    public Housekeeper(final ConfigurationManager configurationManager) {
+    public Housekeeper(final ConfigurationManager configurationManager,
+                       final ConfigStore config,
+                       final RuntimeInfo runtimeInfo) {
         this(configurationManager,
-                60 * 60, // token echeck every 60 min
-                60 * 50 * 24 // cert: check once per day
+                config,
+                runtimeInfo,
+                60 * 60, // token check every 60 min
+                60 * 50 * 24, // cert: check once per day
+                60 * 5 // sync every 5 min
         );
     }
 
 
     public void init() {
+        if (OPENNMS.equals(this.runtimeInfo.getContainer())) {
+            initForOpenNMS();
+        } else if (SENTINEL.equals(this.runtimeInfo.getContainer())) {
+            initForSentinel();
+        } else {
+            log.error("It looks like we are running in a non supported environment, supported=OPENNMS, SENTINEL but it is {}",
+                    this.runtimeInfo.getContainer());
+        }
+
+    }
+
+    private void initForOpenNMS() {
         executor.scheduleAtFixedRate(() -> wrap(this::renewToken), 1, intervalInSecondsForToken, TimeUnit.SECONDS);
         executor.scheduleAtFixedRate(() -> wrap(this::renewCerts), 1, intervalInSecondsForCert, TimeUnit.SECONDS);
+    }
+
+    private void initForSentinel() {
+        executor.scheduleAtFixedRate(() -> wrap(this::syncConfig), 1, intervalForSyncInSeconds, TimeUnit.SECONDS);
     }
 
     public void destroy() {
@@ -93,6 +135,25 @@ public class Housekeeper {
             this.configurationManager.renewCerts();
             this.configurationManager.configure();
         }
+    }
+
+    public void syncConfig() {
+        GrpcConnectionConfig newConfig = createConfig();
+        if (!Objects.equals(this.currentConfig, newConfig)) {
+            // config has changed => sync it
+            configurationManager.configure();
+            this.currentConfig = createConfig();
+        }
+    }
+
+    private GrpcConnectionConfig createConfig() {
+        // Creates a config object with all relevant fields that we want to monitor for change
+        return GrpcConnectionConfig.builder()
+                .privateKey(config.getOrNull(privatekey))
+                .publicKey(config.getOrNull(publickey))
+                .host(config.getOrNull(grpchost))
+                .port(config.get(grpcport).map(Integer::valueOf).orElse(0))
+                .build();
     }
 
     private void wrap(RunnableWithException r) {

--- a/plugin/src/main/java/org/opennms/plugins/cloud/config/KvConfigStore.java
+++ b/plugin/src/main/java/org/opennms/plugins/cloud/config/KvConfigStore.java
@@ -1,0 +1,38 @@
+package org.opennms.plugins.cloud.config;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.opennms.integration.api.v1.distributed.KeyValueStore;
+
+/** ConfigStore backed by KeyValueStore. */
+public class KvConfigStore implements ConfigStore {
+
+    final KeyValueStore<String> store;
+
+    public KvConfigStore(final KeyValueStore<String> keyValueStore) {
+        this.store = Objects.requireNonNull(keyValueStore);
+    }
+
+    @Override
+    public String getOrNull(Key key) {
+        return get(key).orElse(null);
+    }
+
+    @Override
+    public Optional<String> get(Key type) {
+        return store.get(STORE_PREFIX, type.name());
+    }
+
+    @Override
+    public void putProperty(Key key, String value) {
+        store.put(STORE_PREFIX, key.name(), value);
+    }
+
+    @Override
+    public void putProperties(Map<Key, String> properties) {
+        Objects.requireNonNull(properties);
+        properties.forEach((key, value) -> store.put(STORE_PREFIX, key.name(), value));
+    }
+}

--- a/plugin/src/main/java/org/opennms/plugins/cloud/config/KvConfigStore.java
+++ b/plugin/src/main/java/org/opennms/plugins/cloud/config/KvConfigStore.java
@@ -22,17 +22,17 @@ public class KvConfigStore implements ConfigStore {
 
     @Override
     public Optional<String> get(Key type) {
-        return store.get(STORE_PREFIX, type.name());
+        return store.get(type.name(), STORE_PREFIX);
     }
 
     @Override
     public void putProperty(Key key, String value) {
-        store.put(STORE_PREFIX, key.name(), value);
+        store.put(key.name(), value, STORE_PREFIX);
     }
 
     @Override
     public void putProperties(Map<Key, String> properties) {
         Objects.requireNonNull(properties);
-        properties.forEach((key, value) -> store.put(STORE_PREFIX, key.name(), value));
+        properties.forEach((key, value) -> store.put(key.name(), value, STORE_PREFIX));
     }
 }

--- a/plugin/src/main/java/org/opennms/plugins/cloud/config/KvConfigStore.java
+++ b/plugin/src/main/java/org/opennms/plugins/cloud/config/KvConfigStore.java
@@ -4,11 +4,13 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.json.JSONObject;
 import org.opennms.integration.api.v1.distributed.KeyValueStore;
 
 /** ConfigStore backed by KeyValueStore. */
 public class KvConfigStore implements ConfigStore {
 
+    // The KeyValue Store uses Json => we need to provide Json Strings to the store.
     final KeyValueStore<String> store;
 
     public KvConfigStore(final KeyValueStore<String> keyValueStore) {
@@ -22,17 +24,30 @@ public class KvConfigStore implements ConfigStore {
 
     @Override
     public Optional<String> get(Key type) {
-        return store.get(type.name(), STORE_PREFIX);
+        return store
+                .get(type.name(), STORE_PREFIX)
+                .map(this::fromJson);
     }
 
     @Override
     public void putProperty(Key key, String value) {
-        store.put(key.name(), value, STORE_PREFIX);
+        store.put(key.name(), toJson(value), STORE_PREFIX);
     }
 
     @Override
     public void putProperties(Map<Key, String> properties) {
         Objects.requireNonNull(properties);
-        properties.forEach((key, value) -> store.put(key.name(), value, STORE_PREFIX));
+        properties.forEach(this::putProperty);
     }
+
+    public String toJson(final String value) {
+        JSONObject json = new JSONObject();
+        json.put("payload", value);
+        return json.toString();
+    }
+
+    public String fromJson(final String valueJson) {
+        return new JSONObject(valueJson).getString("payload");
+    }
+
 }

--- a/plugin/src/main/java/org/opennms/plugins/cloud/config/PasAccess.java
+++ b/plugin/src/main/java/org/opennms/plugins/cloud/config/PasAccess.java
@@ -36,7 +36,7 @@ import java.util.stream.Collectors;
 
 import org.opennms.dataplatform.access.AuthenticateGrpc;
 import org.opennms.dataplatform.access.AuthenticateOuterClass;
-import org.opennms.plugins.cloud.config.SecureCredentialsVaultUtil.Type;
+import org.opennms.plugins.cloud.config.ConfigStore.Key;
 import org.opennms.plugins.cloud.grpc.GrpcConnection;
 import org.opennms.plugins.cloud.srv.RegistrationManager;
 
@@ -49,21 +49,21 @@ class PasAccess {
         this.grpc = Objects.requireNonNull(grpc);
     }
 
-    Map<Type, String> getCredentialsFromAccessService(final String key, final String systemId) {
+    Map<Key, String> getCredentialsFromAccessService(final String key, final String systemId) {
 
         AuthenticateOuterClass.AuthenticateKeyRequest keyRequest = AuthenticateOuterClass.AuthenticateKeyRequest.newBuilder()
                 .setAuthenticationKey(key)
                 .setSystemUuid(systemId)
                 .build();
         AuthenticateOuterClass.AuthenticateKeyResponse response = grpc.get().authenticateKey(keyRequest);
-        Map<Type, String> attributes = new EnumMap<>(SecureCredentialsVaultUtil.Type.class);
+        Map<Key, String> attributes = new EnumMap<>(Key.class);
         if(response.getGrpcEndpoint().contains(":")) {
             String[] split = response.getGrpcEndpoint().split(":");
-            attributes.put(Type.grpchost, split[0]);
-            attributes.put(Type.grpcport, split[1]);
+            attributes.put(Key.grpchost, split[0]);
+            attributes.put(ConfigStore.Key.grpcport, split[1]);
         }
-        attributes.put(Type.privatekey, response.getPrivateKey());
-        attributes.put(Type.publickey, response.getCertificate());
+        attributes.put(Key.privatekey, response.getPrivateKey());
+        attributes.put(Key.publickey, response.getCertificate());
         return attributes;
     }
 
@@ -94,14 +94,14 @@ class PasAccess {
         return response.getToken();
     }
 
-    public Map<Type, String> renewCertificate(String systemId) {
+    public Map<Key, String> renewCertificate(String systemId) {
         AuthenticateOuterClass.RenewCertificateResponse response = this.grpc.get().renewCertificate(
                 AuthenticateOuterClass.RenewCertificateRequest.newBuilder()
                 .setSystemUuid(systemId)
                 .build());
-        Map<Type, String> attributes = new EnumMap<>(SecureCredentialsVaultUtil.Type.class);
-        attributes.put(Type.privatekey, response.getPrivateKey());
-        attributes.put(Type.publickey, response.getCertificate());
+        Map<Key, String> attributes = new EnumMap<>(Key.class);
+        attributes.put(Key.privatekey, response.getPrivateKey());
+        attributes.put(Key.publickey, response.getCertificate());
         return attributes;
     }
 }

--- a/plugin/src/main/java/org/opennms/plugins/cloud/config/PrerequisiteChecker.java
+++ b/plugin/src/main/java/org/opennms/plugins/cloud/config/PrerequisiteChecker.java
@@ -1,6 +1,9 @@
 package org.opennms.plugins.cloud.config;
 
 
+import org.opennms.integration.api.v1.runtime.Container;
+import org.opennms.integration.api.v1.runtime.RuntimeInfo;
+
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -11,7 +14,7 @@ public class PrerequisiteChecker {
     }
 
     public static void checkAndLogSystemId(final String systemId) {
-        if(isSystemIdOk(systemId)) {
+        if (isSystemIdOk(systemId)) {
             log.info("System id is set to {}", systemId);
         } else {
             log.warn("System id is not set up. It is advisable to set it up, see here: https://github.com/OpenNMS/opennms-cloud-plugin#system-id");
@@ -22,5 +25,14 @@ public class PrerequisiteChecker {
         return systemId != null &&
                 systemId.length() >= 36 &&
                 !systemId.matches("[0-]*");
+    }
+
+    public static void checkAndLogContainer(final RuntimeInfo info) {
+        Container container = info.getContainer();
+        if (container == Container.SENTINEL || container == Container.OPENNMS) {
+            log.info("We are running in {}", container);
+        } else {
+            log.warn("We are running in an unknown container, expect undetermined results! Container = {}", container);
+        }
     }
 }

--- a/plugin/src/main/java/org/opennms/plugins/cloud/config/ScvConfigStore.java
+++ b/plugin/src/main/java/org/opennms/plugins/cloud/config/ScvConfigStore.java
@@ -48,7 +48,7 @@ public class ScvConfigStore implements ConfigStore {
     }
 
     private Optional<Credentials> getCredentials() {
-        return Optional.ofNullable(this.scv.getCredentials(SCV_ALIAS));
+        return Optional.ofNullable(this.scv.getCredentials(STORE_PREFIX));
     }
 
     public String getOrNull(Key type) {
@@ -82,6 +82,6 @@ public class ScvConfigStore implements ConfigStore {
 
         // Store modified credentials
         Credentials newCredentials = new ImmutableCredentials("", "", propertiesToSave);
-        scv.setCredentials(SCV_ALIAS, newCredentials);
+        scv.setCredentials(STORE_PREFIX, newCredentials);
     }
 }

--- a/plugin/src/main/java/org/opennms/plugins/cloud/config/ScvConfigStore.java
+++ b/plugin/src/main/java/org/opennms/plugins/cloud/config/ScvConfigStore.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.plugins.cloud.config;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import org.opennms.integration.api.v1.scv.Credentials;
+import org.opennms.integration.api.v1.scv.SecureCredentialsVault;
+import org.opennms.integration.api.v1.scv.immutables.ImmutableCredentials;
+
+/** ConfigStore backed by SecureCredentialsVault. */
+public class ScvConfigStore implements ConfigStore {
+    private final SecureCredentialsVault scv;
+
+    public ScvConfigStore(SecureCredentialsVault scv) {
+        this.scv = Objects.requireNonNull(scv);
+    }
+
+    private Optional<Credentials> getCredentials() {
+        return Optional.ofNullable(this.scv.getCredentials(SCV_ALIAS));
+    }
+
+    public String getOrNull(Key type) {
+        return get(type)
+                .orElse(null);
+    }
+
+    public Optional<String> get(Key type) {
+        return getCredentials()
+                .map(c -> c.getAttribute(type.name()));
+    }
+
+    public void putProperty(final Key key, String value) {
+        Objects.requireNonNull(key);
+        Objects.requireNonNull(value);
+        putProperties(Collections.singletonMap(key, value));
+    }
+    public void putProperties(final Map<Key, String> properties) {
+        Objects.requireNonNull(properties);
+
+        // retain old values if present
+        Map<String, String> propertiesToSave = new HashMap<>();
+        getCredentials()
+                .map(Credentials::getAttributes)
+                .map(Map::entrySet)
+                .stream()
+                .flatMap(Set::stream)
+                .forEach(e -> propertiesToSave.put(e.getKey(), e.getValue()));
+        properties
+                .forEach((key, value) -> propertiesToSave.put(key.name(), value));
+
+        // Store modified credentials
+        Credentials newCredentials = new ImmutableCredentials("", "", propertiesToSave);
+        scv.setCredentials(SCV_ALIAS, newCredentials);
+    }
+}

--- a/plugin/src/main/java/org/opennms/plugins/cloud/grpc/CloseUtil.java
+++ b/plugin/src/main/java/org/opennms/plugins/cloud/grpc/CloseUtil.java
@@ -57,7 +57,9 @@ public class CloseUtil implements AutoCloseable {
 
     public static void close(final AutoCloseable closable) {
         try {
-            closable.close();
+            if (closable != null) {
+                closable.close();
+            }
         } catch (Exception e) {
             log.warn("An exception occurred while trying to close", e);
         }

--- a/plugin/src/main/java/org/opennms/plugins/cloud/grpc/GrpcConnectionConfig.java
+++ b/plugin/src/main/java/org/opennms/plugins/cloud/grpc/GrpcConnectionConfig.java
@@ -1,6 +1,6 @@
 package org.opennms.plugins.cloud.grpc;
 
-import static org.opennms.plugins.cloud.config.SecureCredentialsVaultUtil.TOKEN_KEY;
+import static org.opennms.plugins.cloud.config.ConfigStore.TOKEN_KEY;
 
 import java.util.Objects;
 

--- a/plugin/src/main/java/org/opennms/plugins/cloud/srv/tsaas/TsaasStorage.java
+++ b/plugin/src/main/java/org/opennms/plugins/cloud/srv/tsaas/TsaasStorage.java
@@ -59,6 +59,8 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import lombok.Getter;
+
 /**
  * The OpenNMS Time series as-a-service storage plugin implementation.
  * <p>
@@ -69,8 +71,9 @@ public class TsaasStorage implements TimeSeriesStorage, GrpcService {
     private final TsaasConfig config;
     private final ConcurrentLinkedDeque<Tsaas.Sample> queue; // holds samples to be batched
     private Instant lastBatchSentTs;
+    @Getter
     @VisibleForTesting
-    GrpcConnection<TimeseriesGrpc.TimeseriesBlockingStub> grpc;
+    private GrpcConnection<TimeseriesGrpc.TimeseriesBlockingStub> grpc;
 
     public TsaasStorage(TsaasConfig config) {
         this.config = Objects.requireNonNull(config);
@@ -129,9 +132,9 @@ public class TsaasStorage implements TimeSeriesStorage, GrpcService {
                 .build();
         LOG.trace("Getting the metrics for the following tags: {}", tagsMessage);
         return executeRpcCall(
-            () -> this.grpc.get().findMetrics(tagsMessage),
-            GrpcObjectMapper::toMetrics,
-            Collections::emptyList
+                () -> this.grpc.get().findMetrics(tagsMessage),
+                GrpcObjectMapper::toMetrics,
+                Collections::emptyList
         );
     }
 
@@ -147,9 +150,9 @@ public class TsaasStorage implements TimeSeriesStorage, GrpcService {
                 .build();
         LOG.trace("Getting time series for request: {}", fetchRequest);
         return executeRpcCall(
-            () -> this.grpc.get().getTimeseriesData(fetchRequest),
-            GrpcObjectMapper::toSamples,
-            Collections::emptyList
+                () -> this.grpc.get().getTimeseriesData(fetchRequest),
+                GrpcObjectMapper::toSamples,
+                Collections::emptyList
         );
     }
 

--- a/plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -76,6 +76,8 @@
     <bean id="houseKeeper" class="org.opennms.plugins.cloud.config.Housekeeper"
           destroy-method="destroy" init-method="init">
         <argument ref="cloudConfigManager"/>
+        <argument ref="configStore"/>
+        <argument ref="runtimeInfo"/>
     </bean>
 
     <!-- HEALTH -->

--- a/plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -7,6 +7,12 @@
 
     <!-- CONFIG -->
     <reference id="secureCredentialsVault" interface="org.opennms.integration.api.v1.scv.SecureCredentialsVault" availability="mandatory"/>
+
+    <bean id="configStore" class="org.opennms.plugins.cloud.config.ScvConfigStore" >
+        <argument ref="secureCredentialsVault"/>
+    </bean>
+    <service ref="configStore" interface="org.opennms.plugins.cloud.config.ConfigStore" />
+
     <reference id="runtimeInfo" interface="org.opennms.integration.api.v1.runtime.RuntimeInfo" availability="mandatory"/>
     <!-- Configuration stored in $OPENNMS_HOME/etc/org.opennms.plugins.cloud.cfg file -->
     <cm:property-placeholder id="tsaas-pocPluginProperties" persistent-id="org.opennms.plugins.cloud"
@@ -43,7 +49,7 @@
     </bean>
 
     <bean id="cloudConfigManager" class="org.opennms.plugins.cloud.config.ConfigurationManager">
-        <argument ref="secureCredentialsVault" />
+        <argument ref="configStore" />
         <argument ref="pasConfigTls"/>
         <argument ref="pasConfigMtls"/>
         <argument ref="registrationManager" />

--- a/plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -6,11 +6,21 @@
                 http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd">
 
     <!-- CONFIG -->
-    <reference id="secureCredentialsVault" interface="org.opennms.integration.api.v1.scv.SecureCredentialsVault" availability="mandatory"/>
 
+    <!-- SecureCredentialsVault backed ConfigStore -->
+    <!-- uncomment this section to use SecureCredentialsVault as config store
+    <reference id="secureCredentialsVault" interface="org.opennms.integration.api.v1.scv.SecureCredentialsVault" availability="mandatory"/>
     <bean id="configStore" class="org.opennms.plugins.cloud.config.ScvConfigStore" >
         <argument ref="secureCredentialsVault"/>
     </bean>
+    -->
+
+    <!-- KeyValue store backed ConfigStore -->
+    <reference id="keyValueStore" interface="org.opennms.integration.api.v1.distributed.KeyValueStore" availability="mandatory"/>
+    <bean id="configStore" class="org.opennms.plugins.cloud.config.KvConfigStore" >
+        <argument ref="keyValueStore"/>
+    </bean>
+
     <service ref="configStore" interface="org.opennms.plugins.cloud.config.ConfigStore" />
 
     <reference id="runtimeInfo" interface="org.opennms.integration.api.v1.runtime.RuntimeInfo" availability="mandatory"/>

--- a/plugin/src/test/java/org/opennms/plugins/cloud/config/ConfigurationManagerCredentialsImportTest.java
+++ b/plugin/src/test/java/org/opennms/plugins/cloud/config/ConfigurationManagerCredentialsImportTest.java
@@ -35,7 +35,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opennms.plugins.cloud.config.ConfigurationManager.ConfigStatus.FAILED;
-import static org.opennms.plugins.cloud.config.SecureCredentialsVaultUtil.SCV_ALIAS;
 
 import java.io.File;
 import java.io.IOException;
@@ -49,7 +48,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.opennms.integration.api.v1.runtime.RuntimeInfo;
-import org.opennms.integration.api.v1.scv.Credentials;
 import org.opennms.plugins.cloud.grpc.GrpcConnectionConfig;
 import org.opennms.plugins.cloud.srv.RegistrationManager;
 import org.opennms.plugins.cloud.srv.tsaas.TsaasStorage;
@@ -73,7 +71,7 @@ public class ConfigurationManagerCredentialsImportTest {
         when(tsaas.checkHealth())
                 .thenReturn(Tsaas.CheckHealthResponse.newBuilder()
                 .setStatus(Tsaas.CheckHealthResponse.ServingStatus.SERVING).build());
-        InMemoryScv scv = new InMemoryScv();
+        InMemoryConfigStore scv = new InMemoryConfigStore();
         ConfigurationManager registrationManager = new ConfigurationManager(scv,
                 GrpcConnectionConfig.builder().build(),
                 GrpcConnectionConfig.builder().build(),
@@ -87,9 +85,7 @@ public class ConfigurationManagerCredentialsImportTest {
         Files.copy(Path.of("src/test/resources/cert/cloud-credentials.zip"), credentialsFile);
         assertTrue(Files.exists(credentialsFile));
         registrationManager.importCloudCredentialsIfPresent();
-        Credentials credentials = scv.getCredentials(SCV_ALIAS);
-        assertNotNull(credentials);
-        String value = credentials.getAttribute(SecureCredentialsVaultUtil.Type.publickey.name());
+        String value = scv.getOrNull(ConfigStore.Key.publickey);
         assertNotNull(value);
         assertTrue(value.startsWith("-----BEGIN CERTIFICATE-----"));
 
@@ -103,7 +99,7 @@ public class ConfigurationManagerCredentialsImportTest {
         when(tsaas.checkHealth())
                 .thenReturn(Tsaas.CheckHealthResponse.newBuilder()
                         .setStatus(Tsaas.CheckHealthResponse.ServingStatus.SERVING).build());
-        InMemoryScv scv = new InMemoryScv();
+        InMemoryConfigStore scv = new InMemoryConfigStore();
         ConfigurationManager configurationManager = new ConfigurationManager(scv,
                 GrpcConnectionConfig.builder().build(),
                 GrpcConnectionConfig.builder().build(),

--- a/plugin/src/test/java/org/opennms/plugins/cloud/config/ConfigurationManagerTest.java
+++ b/plugin/src/test/java/org/opennms/plugins/cloud/config/ConfigurationManagerTest.java
@@ -54,6 +54,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.opennms.integration.api.v1.runtime.RuntimeInfo;
 import org.opennms.integration.api.v1.timeseries.TimeSeriesStorage;
+import org.opennms.plugins.cloud.config.ConfigStore.Key;
 import org.opennms.plugins.cloud.grpc.GrpcConnectionConfig;
 import org.opennms.plugins.cloud.srv.GrpcService;
 import org.opennms.plugins.cloud.srv.RegistrationManager;
@@ -149,7 +150,7 @@ public class ConfigurationManagerTest {
   public void shouldRenewCredentials() throws Exception {
     TsaasStorage grpc = mock(TsaasStorage.class);
     when(grpc.checkHealth()).thenReturn(Tsaas.CheckHealthResponse.newBuilder().setStatus(Tsaas.CheckHealthResponse.ServingStatus.SERVING).build());
-    ConfigurationManager cm = new ConfigurationManager(scv, clientConfig, clientConfig, mock(RegistrationManager.class),
+    ConfigurationManager cm = new ConfigurationManager(config, clientConfig, clientConfig, mock(RegistrationManager.class),
             info,
             Collections.singletonList(grpc));
     assertEquals(NOT_ATTEMPTED, cm.getStatus());
@@ -160,8 +161,8 @@ public class ConfigurationManagerTest {
     verify(grpc, times(1)).initGrpc(any());
 
     cm.renewCerts();
-    assertTrue(scvUtil.getOrNull(SecureCredentialsVaultUtil.Type.privatekey).startsWith("-----BEGIN PRIVATE KEY-----"));
-    assertTrue(scvUtil.getOrNull(SecureCredentialsVaultUtil.Type.publickey).startsWith("-----BEGIN CERTIFICATE-----"));
+    assertTrue(config.getOrNull(Key.privatekey).startsWith("-----BEGIN PRIVATE KEY-----"));
+    assertTrue(config.getOrNull(Key.publickey).startsWith("-----BEGIN CERTIFICATE-----"));
     assertEquals(CONFIGURED, cm.getStatus());
   }
 
@@ -169,7 +170,7 @@ public class ConfigurationManagerTest {
   public void shouldRenewCredentialsFail() {
     TsaasStorage grpc = mock(TsaasStorage.class);
     when(grpc.checkHealth()).thenReturn(Tsaas.CheckHealthResponse.newBuilder().setStatus(Tsaas.CheckHealthResponse.ServingStatus.SERVING).build());
-    ConfigurationManager cm = new ConfigurationManager(scv, clientConfig, clientConfig, mock(RegistrationManager.class),
+    ConfigurationManager cm = new ConfigurationManager(config, clientConfig, clientConfig, mock(RegistrationManager.class),
             info,
             Collections.singletonList(grpc));
     assertThrows(NullPointerException.class, cm::renewCerts); // this will fail because cm was never initialized and configured

--- a/plugin/src/test/java/org/opennms/plugins/cloud/config/InMemoryConfigStore.java
+++ b/plugin/src/test/java/org/opennms/plugins/cloud/config/InMemoryConfigStore.java
@@ -30,26 +30,28 @@ package org.opennms.plugins.cloud.config;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
+import java.util.Optional;
 
-import org.opennms.integration.api.v1.scv.Credentials;
-import org.opennms.integration.api.v1.scv.SecureCredentialsVault;
-
-public final class InMemoryScv implements SecureCredentialsVault {
-    final Map<String, Credentials> creds = new HashMap<>();
+public final class InMemoryConfigStore implements ConfigStore {
+    final Map<Key, String> store = new HashMap<>();
 
     @Override
-    public Set<String> getAliases() {
-        return creds.keySet();
+    public String getOrNull(Key type) {
+        return store.get(type);
     }
 
     @Override
-    public Credentials getCredentials(String s) {
-        return creds.get(s);
+    public Optional<String> get(Key type) {
+        return Optional.ofNullable(getOrNull(type));
     }
 
     @Override
-    public void setCredentials(String s, Credentials credentials) {
-        creds.put(s, credentials);
+    public void putProperty(Key key, String value) {
+        this.store.put(key, value);
+    }
+
+    @Override
+    public void putProperties(Map<Key, String> properties) {
+        this.store.putAll(properties);
     }
 }

--- a/plugin/src/test/java/org/opennms/plugins/cloud/config/KvConfigStoreTest.java
+++ b/plugin/src/test/java/org/opennms/plugins/cloud/config/KvConfigStoreTest.java
@@ -1,0 +1,140 @@
+package org.opennms.plugins.cloud.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.opennms.plugins.cloud.config.ConfigStore.Key;
+import static org.opennms.plugins.cloud.config.ConfigStore.STORE_PREFIX;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.Test;
+import org.opennms.integration.api.v1.distributed.KeyValueStore;
+
+public class KvConfigStoreTest {
+
+    @Test
+    public void shouldFailForNullStore() {
+        assertThrows(NullPointerException.class, () -> new KvConfigStore(null));
+    }
+
+    @Test
+    public void shouldRunCrud() {
+        KvConfigStore store = new KvConfigStore(new InMemoryKvConfigStore());
+        assertEquals(Optional.empty(), store.get(Key.tokenvalue));
+        assertNull(store.getOrNull(Key.tokenvalue));
+        store.putProperty(Key.tokenvalue, "value");
+        assertEquals("value", store.get(Key.tokenvalue).get());
+        assertEquals("value", store.getOrNull(Key.tokenvalue));
+        store.putProperty(Key.tokenvalue, "value2");
+        assertEquals("value2", store.get(Key.tokenvalue).get());
+        assertEquals("value2", store.getOrNull(Key.tokenvalue));
+
+        Map<Key, String> map = new HashMap<>();
+        map.put(Key.tokenvalue, "value3");
+        map.put(Key.tokenkey, "key1");
+        store.putProperties(map);
+        assertEquals("value3", store.get(Key.tokenvalue).get());
+        assertEquals("value3", store.getOrNull(Key.tokenvalue));
+        assertEquals("key1", store.get(Key.tokenkey).get());
+        assertEquals("key1", store.getOrNull(Key.tokenkey));
+    }
+
+    private static class InMemoryKvConfigStore implements KeyValueStore<String> {
+
+        private Map<String, String> store = new HashMap<>();
+
+        @Override
+        public long put(String key, String value, String context) {
+            assertEquals(STORE_PREFIX, context);
+            store.put(key, value);
+            return System.currentTimeMillis();
+        }
+
+        @Override
+        public long put(String key, String value, String context, Integer ttlInSeconds) {
+            throw new UnsupportedOperationException("implement me");
+        }
+
+        @Override
+        public Optional<String> get(String key, String context) {
+            assertEquals(STORE_PREFIX, context);
+            return Optional.ofNullable(this.store.get(key));
+        }
+
+        @Override
+        public Optional<String> getIfStale(String key, String context, long timestamp) {
+            throw new UnsupportedOperationException("implement me");
+        }
+
+        @Override
+        public OptionalLong getLastUpdated(String key, String context) {
+            throw new UnsupportedOperationException("implement me");
+        }
+
+        @Override
+        public Map<String, String> enumerateContext(String context) {
+            throw new UnsupportedOperationException("implement me");
+        }
+
+        @Override
+        public void delete(String key, String context) {
+            throw new UnsupportedOperationException("implement me");
+        }
+
+        @Override
+        public void truncateContext(String context) {
+            throw new UnsupportedOperationException("implement me");
+        }
+
+        @Override
+        public CompletableFuture<Long> putAsync(String key, String value, String context) {
+            throw new UnsupportedOperationException("implement me");
+        }
+
+        @Override
+        public CompletableFuture<Long> putAsync(String key, String value, String context, Integer ttlInSeconds) {
+            throw new UnsupportedOperationException("implement me");
+        }
+
+        @Override
+        public CompletableFuture<Optional<String>> getAsync(String key, String context) {
+            throw new UnsupportedOperationException("implement me");
+        }
+
+        @Override
+        public CompletableFuture<Optional<String>> getIfStaleAsync(String key, String context, long timestamp) {
+            throw new UnsupportedOperationException("implement me");
+        }
+
+        @Override
+        public CompletableFuture<OptionalLong> getLastUpdatedAsync(String key, String context) {
+            throw new UnsupportedOperationException("implement me");
+        }
+
+        @Override
+        public String getName() {
+            throw new UnsupportedOperationException("implement me");
+        }
+
+        @Override
+        public CompletableFuture<Map<String, String>> enumerateContextAsync(String context) {
+            throw new UnsupportedOperationException("implement me");
+        }
+
+        @Override
+        public CompletableFuture<Void> deleteAsync(String key, String context) {
+            throw new UnsupportedOperationException("implement me");
+        }
+
+        @Override
+        public CompletableFuture<Void> truncateContextAsync(String context) {
+            throw new UnsupportedOperationException("implement me");
+        }
+    }
+
+}

--- a/plugin/src/test/java/org/opennms/plugins/cloud/config/PasAccessTest.java
+++ b/plugin/src/test/java/org/opennms/plugins/cloud/config/PasAccessTest.java
@@ -40,7 +40,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.opennms.dataplatform.access.AuthenticateGrpc;
 import org.opennms.dataplatform.access.AuthenticateOuterClass;
-import org.opennms.plugins.cloud.config.SecureCredentialsVaultUtil.Type;
+import org.opennms.plugins.cloud.config.ConfigStore.Key;
 import org.opennms.plugins.cloud.grpc.GrpcConnection;
 import org.opennms.plugins.cloud.srv.RegistrationManager;
 
@@ -59,7 +59,6 @@ public class PasAccessTest {
     @Test
     public void shouldConfigure() throws IOException {
         ConfigZipExtractor zip =  new ConfigZipExtractor(Path.of("src/test/resources/cert/cloud-credentials.zip"));
-        InMemoryScv scv = new InMemoryScv();
         final String serverHost = "myHost";
         final int serverPort = 12345;
         final String privateKey = zip.getPrivateKey();
@@ -123,19 +122,19 @@ public class PasAccessTest {
         GrpcConnection<AuthenticateGrpc.AuthenticateBlockingStub> grpc = new GrpcConnection<>(stub, channel);
         PasAccess pas = new PasAccess(grpc);
 
-        Map<Type, String> config = pas.getCredentialsFromAccessService("key", "systemId");
-        assertEquals(serverHost, config.get(Type.grpchost));
-        assertEquals(Integer.toString(serverPort), config.get(Type.grpcport));
-        assertEquals(privateKey, config.get(Type.privatekey));
-        assertEquals(certificate, config.get(Type.publickey));
+        Map<Key, String> config = pas.getCredentialsFromAccessService("key", "systemId");
+        assertEquals(serverHost, config.get(ConfigStore.Key.grpchost));
+        assertEquals(Integer.toString(serverPort), config.get(Key.grpcport));
+        assertEquals(privateKey, config.get(ConfigStore.Key.privatekey));
+        assertEquals(certificate, config.get(Key.publickey));
         // FAAS shouldn't show up since it is not enabled:
         assertEquals(Set.of(RegistrationManager.Service.TSAAS), pas.getActiveServices("systemId"));
         assertEquals("myToken", pas.getToken(new HashSet<>(), "systemId"));
 
         // renew certs
-        Map<Type, String> newCerts = pas.renewCertificate("systemId");
-        assertEquals(privateKey, newCerts.get(Type.privatekey));
-        assertEquals(certificate, newCerts.get(Type.publickey));
+        Map<Key, String> newCerts = pas.renewCertificate("systemId");
+        assertEquals(privateKey, newCerts.get(Key.privatekey));
+        assertEquals(certificate, newCerts.get(Key.publickey));
 
         server.shutdown();
     }

--- a/plugin/src/test/java/org/opennms/plugins/cloud/config/SecureCredentialsVaultUtilTypeTest.java
+++ b/plugin/src/test/java/org/opennms/plugins/cloud/config/SecureCredentialsVaultUtilTypeTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 public class SecureCredentialsVaultUtilTypeTest {
     @Test
     public void typeNamesMustBeLowerCase() {
-        for(SecureCredentialsVaultUtil.Type type : SecureCredentialsVaultUtil.Type .values()) {
+        for(ConfigStore.Key type : ConfigStore.Key.values()) {
             if(!type.name().equals(type.name().toLowerCase())) {
                 fail(type.name() + " must be lower case. Otherwise the scv won't work properly.");
             }

--- a/plugin/src/test/java/org/opennms/plugins/cloud/config/SvcConfigStoreTest.java
+++ b/plugin/src/test/java/org/opennms/plugins/cloud/config/SvcConfigStoreTest.java
@@ -1,0 +1,67 @@
+package org.opennms.plugins.cloud.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.opennms.plugins.cloud.config.ConfigStore.Key;
+import static org.opennms.plugins.cloud.config.ConfigStore.STORE_PREFIX;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.Test;
+import org.opennms.integration.api.v1.scv.Credentials;
+import org.opennms.integration.api.v1.scv.SecureCredentialsVault;
+
+public class SvcConfigStoreTest {
+
+    @Test
+    public void shouldFailForNullStore() {
+        assertThrows(NullPointerException.class, () -> new KvConfigStore(null));
+    }
+
+    @Test
+    public void shouldRunCrud() {
+        ScvConfigStore store = new ScvConfigStore(new InMemoryScvConfigStore());
+        assertEquals(Optional.empty(), store.get(Key.tokenvalue));
+        assertNull(store.getOrNull(Key.tokenvalue));
+        store.putProperty(Key.tokenvalue, "value");
+        assertEquals("value", store.get(Key.tokenvalue).get());
+        assertEquals("value", store.getOrNull(Key.tokenvalue));
+        store.putProperty(Key.tokenvalue, "value2");
+        assertEquals("value2", store.get(Key.tokenvalue).get());
+        assertEquals("value2", store.getOrNull(Key.tokenvalue));
+
+        Map<Key, String> map = new HashMap<>();
+        map.put(Key.tokenvalue, "value3");
+        map.put(Key.tokenkey, "key1");
+        store.putProperties(map);
+        assertEquals("value3", store.get(Key.tokenvalue).get());
+        assertEquals("value3", store.getOrNull(Key.tokenvalue));
+        assertEquals("key1", store.get(Key.tokenkey).get());
+        assertEquals("key1", store.getOrNull(Key.tokenkey));
+    }
+
+    private static class InMemoryScvConfigStore implements SecureCredentialsVault {
+
+        private Credentials credentials;
+
+        @Override
+        public Set<String> getAliases() {
+            return Collections.singleton(STORE_PREFIX);
+        }
+        @Override
+        public Credentials getCredentials(String alias) {
+            assertEquals(STORE_PREFIX, alias);
+            return this.credentials;
+        }
+        @Override
+        public void setCredentials(String alias, Credentials credentials) {
+            this.credentials = credentials;
+        }
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
         <tsaasClientVersion>LATEST</tsaasClientVersion>
         <pasClientVersion>0.8.0</pasClientVersion><!-- PAS service -->
         <java.version>11</java.version>
+        <jsonVersion>20220924</jsonVersion>
         <jwtVersion>4.0.0</jwtVersion>
         <zstd.version>1.5.0-2</zstd.version>
         <junit.version>4.13.2</junit.version>


### PR DESCRIPTION
This PR is part I of [DC-219 OpenNSM core is able to share config with sentinels  project](https://issues.opennms.org/browse/DC-219)
- switches storage of certs from SecureStorageVault to KeyBalueStore
- distinguishes between core and sentinel.
- if core: get certs from PAS, if sentinel get certs from KVStore 