### PR TITLE
DC-321: upgrade log4j ver. due to securty vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <zstd.version>1.5.0-2</zstd.version>
         <junit.version>4.13.2</junit.version>
         <karaf.version>4.3.6</karaf.version>
-        <log4j.version>2.13.3</log4j.version>
+        <log4j.version>2.18.0</log4j.version>
         <mockito.version>2.18.0</mockito.version>
         <opennms.api.version>1.0.1</opennms.api.version>
         <osgi.version>6.0.0</osgi.version>


### PR DESCRIPTION
https://issues.opennms.org/browse/DC-321

Using 2.18.0 is due to sync with horizon ver.