### PR TITLE
DC-368: Vite before v2.9.13 vulnerability

### DIFF
--- a/plugin-core/src/main/ui/package.json
+++ b/plugin-core/src/main/ui/package.json
@@ -31,11 +31,11 @@
   },
   "devDependencies": {
     "@types/node": "18.0.0",
-    "@vitejs/plugin-vue": "2.2.0",
+    "@vitejs/plugin-vue": "^3.0.3",
     "sass": "1.54.3",
     "typescript": "^4.5.4",
-    "vite": "2.8.0",
-    "vue-tsc": "0.38.1"
+    "vite": "^3.0.7",
+    "vue-tsc": "^0.40.1"
   },
   "packageManager": "yarn@3.2.2"
 }


### PR DESCRIPTION
https://issues.opennms.org/browse/DC-368