### PR TITLE
DC-404 Parametrize ver. of cloud plugin in EndToEndIt

### DIFF
--- a/it-test/pom.xml
+++ b/it-test/pom.xml
@@ -124,5 +124,11 @@
         <artifactId>lombok</artifactId>
         <scope>provided</scope>
       </dependency>
+      <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-model</artifactId>
+        <version>3.8.6</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
 </project>

--- a/it-test/src/test/java/org/opennms/plugins/cloud/ittest/EndToEndIt.java
+++ b/it-test/src/test/java/org/opennms/plugins/cloud/ittest/EndToEndIt.java
@@ -28,14 +28,20 @@
 
 package org.opennms.plugins.cloud.ittest;
 
+import static java.lang.String.format;
 import static org.opennms.plugins.cloud.ittest.MockCloudMain.MOCK_CLOUD_HOST;
 import static org.opennms.plugins.cloud.ittest.MockCloudMain.MOCK_CLOUD_PORT;
 import static org.opennms.plugins.cloud.testserver.FileUtil.classpathFileToString;
 
 import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.time.Duration;
 
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -63,10 +69,16 @@ public class EndToEndIt {
     private KarafShell opennmsShell;
     private KarafShell sentinelShell;
 
+    private static String pluginVersion;
+
     @BeforeClass
-    public static void beforeAll() {
+    public static void beforeAll() throws IOException, XmlPullParserException {
+        MavenXpp3Reader mavenXpp3Reader = new MavenXpp3Reader();
+        Model model = mavenXpp3Reader.read(new FileReader("pom.xml"));
+        pluginVersion = model.getParent().getVersion();
         environment = new DockerComposeContainer<>(new File("src/test/resources/docker-compose.yaml"))
                 .withEnv("USER_HOME", System.getProperty("user.home"))
+                .withEnv("PLUGIN_VERSION", pluginVersion)
                 .withTailChildContainers(true)
                 .withExposedService("database_1", 5432, Wait.forListeningPort().withStartupTimeout(Duration.ofSeconds(15)))
                 .withLogConsumer("database_1", new Slf4jLogConsumer(LOG))
@@ -107,7 +119,7 @@ public class EndToEndIt {
     private void installAndStartPluginInOpenNms() {
 
         // install plugin for core
-        opennmsShell.runCommand("kar:install --no-start mvn:org.opennms.plugins.cloud.assembly/org.opennms.plugins.cloud.assembly.kar/1.0.1-SNAPSHOT/kar");
+        opennmsShell.runCommand(format("kar:install --no-start mvn:org.opennms.plugins.cloud.assembly/org.opennms.plugins.cloud.assembly.kar/%s/kar", pluginVersion));
         opennmsShell.runCommand("feature:install opennms-plugin-cloud-core");
 
         // check if plugin has been started, if so we assume the installation worked well.
@@ -125,7 +137,7 @@ public class EndToEndIt {
     private void installAndStartPluginInSentinel() {
 
         // install plugin for core
-        sentinelShell.runCommand("kar:install --no-start mvn:org.opennms.plugins.cloud.assembly/org.opennms.plugins.cloud.assembly.kar/1.0.1-SNAPSHOT/kar");
+        sentinelShell.runCommand(format("kar:install --no-start mvn:org.opennms.plugins.cloud.assembly/org.opennms.plugins.cloud.assembly.kar/%s/kar", pluginVersion));
         sentinelShell.runCommand("feature:install opennms-plugin-cloud-sentinel");
 
         // check if plugin has been started, if so we assume the installation worked well.
@@ -142,7 +154,7 @@ public class EndToEndIt {
     }
 
     private String createConfig() {
-        return String.format(
+        return format(
                 "config:edit org.opennms.plugins.cloud%n"
                         + "property-set pas.tls.host %s%n"
                         + "property-set pas.tls.port %s%n"
@@ -162,7 +174,7 @@ public class EndToEndIt {
 
     private static ContainerState getContainer(final String container) {
         return environment.getContainerByServiceName(container)
-                .orElseThrow(() -> new IllegalArgumentException(String.format("container %s not found", container)));
+                .orElseThrow(() -> new IllegalArgumentException(format("container %s not found", container)));
     }
 
     private static void printContainerStartup(String container) {

--- a/it-test/src/test/resources/docker-compose.yaml
+++ b/it-test/src/test/resources/docker-compose.yaml
@@ -28,10 +28,10 @@ services:
     image: "opennms/deploy-base:jre-2.0.6.b165"
     hostname: cloudMock
     entrypoint: /bin/bash
-    command: ["-c", "java -cp /usr/share/opennms/.m2/repository/org/opennms/plugins/cloud/it-test/1.0.1-SNAPSHOT/it-test-1.0.1-SNAPSHOT-jar-with-dependencies.jar org.opennms.plugins.cloud.ittest.MockCloudMain"]
+    command: ["-c", "java -cp /usr/share/opennms/.m2/repository/org/opennms/plugins/cloud/it-test/${PLUGIN_VERSION}/it-test-${PLUGIN_VERSION}-jar-with-dependencies.jar org.opennms.plugins.cloud.ittest.MockCloudMain"]
     volumes:
       # the path is a bit ugly but the jar is not yet in the local mvn repo.
-      - ../../../target:/usr/share/opennms/.m2/repository/org/opennms/plugins/cloud/it-test/1.0.1-SNAPSHOT:ro
+      - ../../../target:/usr/share/opennms/.m2/repository/org/opennms/plugins/cloud/it-test/${PLUGIN_VERSION}:ro
     ports:
       - "9003:9003/tcp" # mock server port
 
@@ -47,7 +47,7 @@ services:
       TZ: ${TIMEZONE:-America/New_York}
     volumes:
       # we overlay folder with kar into maven repo. It contains the plugin jars and dependencies:
-      - ../../../../assembly/kar/target/opennms-plugin-cloud.kar:/usr/share/opennms/.m2/repository/org/opennms/plugins/cloud/assembly/org.opennms.plugins.cloud.assembly.kar/1.0.1-SNAPSHOT/org.opennms.plugins.cloud.assembly.kar-1.0.1-SNAPSHOT.kar:ro
+      - ../../../../assembly/kar/target/opennms-plugin-cloud.kar:/usr/share/opennms/.m2/repository/org/opennms/plugins/cloud/assembly/org.opennms.plugins.cloud.assembly.kar/${PLUGIN_VERSION}/org.opennms.plugins.cloud.assembly.kar-${PLUGIN_VERSION}.kar:ro
     command: ["-s"]
     ports:
       - "8101:8101/tcp" # ssh port for karaf console
@@ -70,7 +70,7 @@ services:
       JAVA_MAX_MEM: 2048M
     volumes:
       # we overlay folder with kar into system repo. It contains the plugin jars and dependencies:
-      - ../../../../assembly/kar/target/opennms-plugin-cloud.kar:/usr/share/sentinel/.m2/repository/org/opennms/plugins/cloud/assembly/org.opennms.plugins.cloud.assembly.kar/1.0.1-SNAPSHOT/org.opennms.plugins.cloud.assembly.kar-1.0.1-SNAPSHOT.kar:ro
+      - ../../../../assembly/kar/target/opennms-plugin-cloud.kar:/usr/share/sentinel/.m2/repository/org/opennms/plugins/cloud/assembly/org.opennms.plugins.cloud.assembly.kar/${PLUGIN_VERSION}/org.opennms.plugins.cloud.assembly.kar-${PLUGIN_VERSION}.kar:ro
     command: ["-f"]
     ports:
       - "8301:8301/tcp" # ssh port for karaf console


### PR DESCRIPTION
- Using maven model library to parse pom.xml and extract project version
- use parameter instead of hardcoded version number in Test and docker-compose file
- added dependency in pom.xml

Jira: https://issues.opennms.org/browse/DC-404