### PR TITLE
CLOUD-2754, CLOUD-2755: Adding Status bar component and rework cloud plugin UI

### DIFF
--- a/plugin-common/src/main/java/org/opennms/plugins/cloud/config/ConfigurationManager.java
+++ b/plugin-common/src/main/java/org/opennms/plugins/cloud/config/ConfigurationManager.java
@@ -32,6 +32,7 @@ import static org.opennms.plugins.cloud.config.ConfigStore.Key.truststore;
 import static org.opennms.plugins.cloud.config.ConfigStore.TOKEN_KEY;
 import static org.opennms.plugins.cloud.config.ConfigurationManager.ConfigStatus.AUTHENTCATED;
 import static org.opennms.plugins.cloud.config.ConfigurationManager.ConfigStatus.CONFIGURED;
+import static org.opennms.plugins.cloud.config.ConfigurationManager.ConfigStatus.DEACTIVATED;
 import static org.opennms.plugins.cloud.config.PrerequisiteChecker.checkAndLogContainer;
 import static org.opennms.plugins.cloud.config.PrerequisiteChecker.checkAndLogSystemId;
 
@@ -78,7 +79,11 @@ public class ConfigurationManager {
         /**
          * The cloud plugin is configured but the configuration failed.
          */
-        FAILED
+        FAILED,
+        /**
+         * The cloud plugin is successfully deactivated (After previously being activated).
+         */
+        DEACTIVATED,
     }
 
     private static final Logger LOG = LoggerFactory.getLogger(ConfigurationManager.class);
@@ -159,6 +164,13 @@ public class ConfigurationManager {
             LOG.error("Initialization failed. Used config:\n{}", pasConfigTls, e);
             throw e;
         }
+    }
+
+    /**
+    * This is a placeholder and doesn't currently deactivate on the backend
+    */
+    public void deactivateKeyConfiguration(final String key) {
+        this.currentStatus = DEACTIVATED;
     }
 
     public void renewCerts() throws CertificateException {

--- a/plugin-core/src/main/java/org/opennms/plugins/cloud/rest/CloudConfigRestService.java
+++ b/plugin-core/src/main/java/org/opennms/plugins/cloud/rest/CloudConfigRestService.java
@@ -42,6 +42,10 @@ public interface CloudConfigRestService {
     @Path("/activationkey")
     Response putActivationKey(final String key);
 
+    @PUT
+    @Path("/deactivatekey")
+    Response putDeactivateKey(final String key);
+
     @GET
     @Path("/status")
     @Produces(value = {MediaType.APPLICATION_JSON})

--- a/plugin-core/src/main/java/org/opennms/plugins/cloud/rest/CloudConfigRestServiceImpl.java
+++ b/plugin-core/src/main/java/org/opennms/plugins/cloud/rest/CloudConfigRestServiceImpl.java
@@ -62,8 +62,8 @@ public class CloudConfigRestServiceImpl implements CloudConfigRestService {
     public Response putDeactivateKey(final String keyJson) {
         try {
             String key = extractKey(keyJson);
-            //this.cm.initConfiguration(key);
-            //this.cm.configure();
+            this.cm.initConfiguration(key);
+            this.cm.configure();
             this.cm.deactivateKeyConfiguration(key);
             
         } catch (Exception e) {

--- a/plugin-core/src/main/java/org/opennms/plugins/cloud/rest/CloudConfigRestServiceImpl.java
+++ b/plugin-core/src/main/java/org/opennms/plugins/cloud/rest/CloudConfigRestServiceImpl.java
@@ -58,6 +58,23 @@ public class CloudConfigRestServiceImpl implements CloudConfigRestService {
         return getStatus();
     }
 
+    @Override
+    public Response putDeactivateKey(final String keyJson) {
+        try {
+            String key = extractKey(keyJson);
+            //this.cm.initConfiguration(key);
+            //this.cm.configure();
+            this.cm.deactivateKeyConfiguration(key);
+            
+        } catch (Exception e) {
+            return Response
+                    .status(Response.Status.INTERNAL_SERVER_ERROR)
+                    .entity(exceptionToJson(e))
+                    .build();
+        }
+        return getStatus();
+    }
+
     String extractKey(final String json) {
         return new JSONObject(json)
                 .getJSONObject("key")

--- a/plugin-core/src/main/ui/package.json
+++ b/plugin-core/src/main/ui/package.json
@@ -21,6 +21,7 @@
     "@featherds/button": "0.11.1",
     "@featherds/icon": "0.11.1",
     "@featherds/dialog": "0.11.1",
+    "@featherds/progress": "0.11.1",
     "@featherds/snackbar": "0.11.1",
     "@featherds/styles": "0.11.1",
     "@featherds/textarea": "0.11.1",

--- a/plugin-core/src/main/ui/package.json
+++ b/plugin-core/src/main/ui/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@featherds/button": "0.11.1",
     "@featherds/icon": "0.11.1",
+    "@featherds/dialog": "0.11.1",
     "@featherds/snackbar": "0.11.1",
     "@featherds/styles": "0.11.1",
     "@featherds/textarea": "0.11.1",

--- a/plugin-core/src/main/ui/src/components/CloudPlugin.vue
+++ b/plugin-core/src/main/ui/src/components/CloudPlugin.vue
@@ -38,7 +38,7 @@ const updateStatus = async () => {
 }
 
 const routeToHome = () => {
-  window.location.href = window.location.hostname + '/';
+  window.location.href = window.location.origin + '/opennms';
 }
 
 /**
@@ -63,7 +63,6 @@ const submit = async (deactivate?: boolean) => {
     notification.value = jsonResponse.status;
     show.value = true;
     if (jsonResponse.success) {
-        // do something
         status.value = jsonResponse.status;
         show.value = true;
     }

--- a/plugin-core/src/main/ui/src/components/CloudPlugin.vue
+++ b/plugin-core/src/main/ui/src/components/CloudPlugin.vue
@@ -30,8 +30,6 @@ const updateStatus = async () => {
   try {
     const jsonResponse = await val.json();
     status.value = jsonResponse.status;
-    notification.value = jsonResponse.status;
-    show.value = true;
   } catch (e: any) {
     notification.value = e?.status || e;
     show.value = true;

--- a/plugin-core/src/main/ui/src/components/CloudPlugin.vue
+++ b/plugin-core/src/main/ui/src/components/CloudPlugin.vue
@@ -2,16 +2,20 @@
 import { FeatherButton } from "@featherds/button";
 import { FeatherTextarea } from '@featherds/textarea'
 import { FeatherSnackbar } from '@featherds/snackbar'
+import { FeatherDialog } from "@featherds/dialog";
 import { onMounted, ref } from "vue";
 import Toggle from './Toggle.vue'
+import StatusBar from './StatusBar.vue';
 
 const active = ref(false);
+const activated = ref(false);
 const toggle = () => active.value = !active.value
 const status = ref({});
 const notification = ref({});
 const show = ref(false);
 const key = ref('');
 const keyDisabled = ref(false);
+const visible = ref(false);
 
 
 /**
@@ -61,6 +65,15 @@ const tryToSubmit = () => {
   // show.value = true;
   submitKey();
 }
+const tryToDeactivate = () => {
+  console.log('deactivating');
+  //submitKey();
+}
+
+const cancel = () => {
+  console.log('cancel');
+  //route to previous page if router is available
+};
 
 onMounted(async () => {
   // notification.value = 'Plugin Mounted. Faking API Status call';
@@ -78,19 +91,38 @@ onMounted(async () => {
     </template>
   </FeatherSnackbar>
   <div class="center">
-    <h1>Cloud Services</h1>
+    <h1>
+      OpenNMS Cloud Services
+      <StatusBar :status="status" />
+    </h1>
+  
     <p class="margin-bottom">Activate OpenNMS cloud-hosted services including 
       <a target="_blank" href="https://docs.opennms.com/horizon/latest/deployment/time-series-storage/timeseries/hosted-tss.html">time series storage</a>.
     </p>
     <Toggle :active="active" :toggle="toggle" activeText="Cloud Services Activated"
       disabledText="Cloud Services Deactivated" />
-    <div class="key-entry" v-if="active">
+    <div class="key-entry" v-if="active && !activated">
       <p class="smaller">To activate, generate a key in the OpenNMS Portal and paste it here.</p>
-      <FeatherTextarea :disabled="keyDisabled" label="Enter Activation Key" rows="5" :modelValue="key"
-        @update:modelValue="(val: string) => key = val" />
-      <FeatherButton primary @click="tryToSubmit">Activate</FeatherButton>
+      <div v-if="!activated">
+        <FeatherTextarea :disabled="keyDisabled" label="Enter Activation Key" rows="5" :modelValue="key"
+          @update:modelValue="(val: string) => key = val" />
+        <FeatherButton text @click="cancel">Cancel</FeatherButton>
+        <FeatherButton primary @click="tryToSubmit">Activate</FeatherButton>
+      </div>
+      <div v-if="activated">
+        <FeatherButton text @click="cancel">Return to Dashboard</FeatherButton>
+        <FeatherButton primary @click="tryToDeactivate">Deactivate Cloud Services</FeatherButton>
+      </div>
     </div>
   </div>
+  <FeatherDialog>
+      <p class="my-content">A message from the Dialog</p>
+      <template v-slot:footer>
+        <FeatherButton primary @click="visible = false"
+          >Close Dialog</FeatherButton
+        >
+      </template>
+  </FeatherDialog>
 </template>
 
 

--- a/plugin-core/src/main/ui/src/components/StatusBar.vue
+++ b/plugin-core/src/main/ui/src/components/StatusBar.vue
@@ -1,22 +1,25 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { FeatherIcon } from "@featherds/icon";
 import CheckCircle from '@featherds/icon/action/CheckCircle';
 import Cancel from '@featherds/icon/action/Cancel';
 import Cycle from '@featherds/icon/action/Cycle';
-const status = ref('activated');
+
+const props = defineProps({
+    status: { type: String, default: 'activating' }
+});
 
 </script>
 
 <template>
-    <div v-if="status === 'deactivated'" class="deactivated statusbar">
-        <FeatherIcon :icon="Cancel" />Not activated
-    </div>
-    <div v-if="status === 'activating'" class="activating statusbar">
-        <FeatherIcon :icon="Cycle"/>Activating...
-    </div>
     <div v-if="status === 'activated'" class="activated statusbar">
         <FeatherIcon :icon="CheckCircle"/>
         Activated
+    </div>
+    <div v-else-if="status === 'activating'" class="activating statusbar">
+        <FeatherIcon :icon="Cycle"/>Activating...
+    </div>
+    <div v-else class="deactivated statusbar">
+        <FeatherIcon :icon="Cancel" />Not activated
     </div>
 </template>
 
@@ -54,6 +57,8 @@ const status = ref('activated');
     font-weight: 500;
     font-size: 12px;
     line-height: 15px;
+    margin-left: 20px;
+    margin-top: 8px;
 
     /* identical to box height */
     font-feature-settings: 'tnum' on, 'lnum' on, 'cv05' on;

--- a/plugin-core/src/main/ui/src/components/StatusBar.vue
+++ b/plugin-core/src/main/ui/src/components/StatusBar.vue
@@ -12,14 +12,13 @@ const props = defineProps({
 
 <template>
     <div v-if="status === 'activated'" class="activated statusbar">
-        <FeatherIcon :icon="CheckCircle"/>
-        Activated
+        <FeatherIcon :icon="CheckCircle"/> Activated
     </div>
     <div v-else-if="status === 'activating'" class="activating statusbar">
-        <FeatherIcon :icon="Cycle"/>Activating...
+        <FeatherIcon :icon="Cycle"/> Activating...
     </div>
     <div v-else class="deactivated statusbar">
-        <FeatherIcon :icon="Cancel" />Not activated
+        <FeatherIcon :icon="Cancel" /> Not activated
     </div>
 </template>
 
@@ -58,10 +57,14 @@ const props = defineProps({
     font-size: 12px;
     line-height: 15px;
     margin-left: 20px;
-    margin-top: 8px;
+    margin-top: 6px;
 
     /* identical to box height */
     font-feature-settings: 'tnum' on, 'lnum' on, 'cv05' on;
+}
+
+FeatherIcon { 
+  margin-right: 10px;
 }
 
 </style>

--- a/plugin-core/src/main/ui/src/components/StatusBar.vue
+++ b/plugin-core/src/main/ui/src/components/StatusBar.vue
@@ -1,19 +1,21 @@
 <script setup lang="ts">
 import { ref } from 'vue';
-
-const status = ref('deactivated');
+import CheckCircle from '@featherds/icon/action/CheckCircle';
+import Cancel from '@featherds/icon/action/Cancel';
+import Cycle from '@featherds/icon/action/Cycle';
+const status = ref('activated');
 
 </script>
 
 <template>
     <div v-if="status === 'deactivated'" class="deactivated statusbar">
-        <FeatherIcon>Not activated</FeatherIcon>
+        <FeatherIcon :icon="Cancel" />Not activated
     </div>
-    <div v-if="status === 'activating'" class="activating">
-        <FeatherIcon>Activating...</FeatherIcon>
+    <div v-if="status === 'activating'" class="activating statusbar">
+        <FeatherIcon :icon="Cycle"/>Activating...
     </div>
-    <div v-if="status === 'activated'" class="activated">
-        <FeatherIcon />
+    <div v-if="status === 'activated'" class="activated statusbar">
+        <FeatherIcon :icon="CheckCircle"/>
         Activated
     </div>
 </template>
@@ -21,19 +23,40 @@ const status = ref('deactivated');
 <style scoped lang="scss">
 
 .deactivated {
-    background-color: grey;
+    background-color: rgba(117, 117, 117, 0.2);
+    color: #757575;
+    width: 115px;
 }
 
 .activating {
-    background-color: lightblue;
+    background-color: rgba(0, 146, 199, 0.2);
+    color: #0092C7;
+    width: 105px;
 }
 
 .activated {
-    background-color: green;
+    background: rgba(11, 114, 12, 0.2);
+    color: #0B720C;
+    width: 91 px;
 }
 
-.statsbar {
-    border-radius: 1rem;
+.statusbar {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    padding: 4px 6px;
+    // border-radius: 0.5rem;
+    height: 28px;
+    border-radius: 4px;
+    font-family: 'Inter';
+    font-style: normal;
+    font-weight: 500;
+    font-size: 12px;
+    line-height: 15px;
+
+    /* identical to box height */
+    font-feature-settings: 'tnum' on, 'lnum' on, 'cv05' on;
 }
 
 </style>

--- a/plugin-core/src/main/ui/src/components/StatusBar.vue
+++ b/plugin-core/src/main/ui/src/components/StatusBar.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+
+const status = ref('deactivated');
+
+</script>
+
+<template>
+    <div v-if="status === 'deactivated'" class="deactivated statusbar">
+        <FeatherIcon>Not activated</FeatherIcon>
+    </div>
+    <div v-if="status === 'activating'" class="activating">
+        <FeatherIcon>Activating...</FeatherIcon>
+    </div>
+    <div v-if="status === 'activated'" class="activated">
+        <FeatherIcon />
+        Activated
+    </div>
+</template>
+
+<style scoped lang="scss">
+
+.deactivated {
+    background-color: grey;
+}
+
+.activating {
+    background-color: lightblue;
+}
+
+.activated {
+    background-color: green;
+}
+
+.statsbar {
+    border-radius: 1rem;
+}
+
+</style>

--- a/plugin-core/src/test/java/org/opennms/plugins/cloud/rest/CloudConfigRestServiceImplTest.java
+++ b/plugin-core/src/test/java/org/opennms/plugins/cloud/rest/CloudConfigRestServiceImplTest.java
@@ -96,7 +96,7 @@ public class CloudConfigRestServiceImplTest {
 
     @Test
     public void shouldPutDeactivateKey() {
-        when(cm.getStatus()).thenReturn(CONFIGURED);
+        when(cm.getStatus()).thenReturn(DEACTIVATED);
         Response response = new CloudConfigRestServiceImpl(cm)
                 .putDeactivateKey(API_KEY_JSON);
         assertEquals(200, response.getStatus());

--- a/plugin-core/src/test/java/org/opennms/plugins/cloud/rest/CloudConfigRestServiceImplTest.java
+++ b/plugin-core/src/test/java/org/opennms/plugins/cloud/rest/CloudConfigRestServiceImplTest.java
@@ -111,7 +111,8 @@ public class CloudConfigRestServiceImplTest {
         when(cm.getStatus()).thenReturn(FAILED);
         Response response = new CloudConfigRestServiceImpl(cm)
                 .putDeactivateKey(API_KEY_JSON);
-        assertEquals(500, response.getStatus());
+        //This temporarily comes back as 200 but should be 500
+        assertEquals(200, response.getStatus());
         String entity = (String) response.getEntity();
         JSONObject json = new JSONObject(entity);
         assertEquals(FAILED.name(), json.get("status"));

--- a/plugin-core/src/test/java/org/opennms/plugins/cloud/rest/CloudConfigRestServiceImplTest.java
+++ b/plugin-core/src/test/java/org/opennms/plugins/cloud/rest/CloudConfigRestServiceImplTest.java
@@ -112,7 +112,7 @@ public class CloudConfigRestServiceImplTest {
         Response response = new CloudConfigRestServiceImpl(cm)
                 .putDeactivateKey(API_KEY_JSON);
         //This temporarily comes back as 200 but should be 500
-        assertEquals(200, response.getStatus());
+        assertEquals(500, response.getStatus());
         String entity = (String) response.getEntity();
         JSONObject json = new JSONObject(entity);
         assertEquals(FAILED.name(), json.get("status"));

--- a/plugin-core/src/test/java/org/opennms/plugins/cloud/rest/CloudConfigRestServiceImplTest.java
+++ b/plugin-core/src/test/java/org/opennms/plugins/cloud/rest/CloudConfigRestServiceImplTest.java
@@ -105,16 +105,16 @@ public class CloudConfigRestServiceImplTest {
         assertEquals(DEACTIVATED.name(), json.get("status"));
     }
 
-    // @Test
-    // public void shouldPutActivationKeyWithException() {
-    //     doThrow(new NullPointerException("ohoh")).when(cm).initConfiguration(anyString());
-    //     when(cm.getStatus()).thenReturn(FAILED);
-    //     Response response = new CloudConfigRestServiceImpl(cm)
-    //             .putActivationKey(API_KEY_JSON);
-    //     assertEquals(500, response.getStatus());
-    //     String entity = (String) response.getEntity();
-    //     JSONObject json = new JSONObject(entity);
-    //     assertEquals(FAILED.name(), json.get("status"));
-    //     assertEquals("ohoh", json.get("message"));
-    // }
+    @Test
+    public void shouldPutDeactivateKeyWithException() {
+        doThrow(new NullPointerException("failed_deactivate")).when(cm).initConfiguration(anyString());
+        when(cm.getStatus()).thenReturn(FAILED);
+        Response response = new CloudConfigRestServiceImpl(cm)
+                .putDeactivateKey(API_KEY_JSON);
+        assertEquals(500, response.getStatus());
+        String entity = (String) response.getEntity();
+        JSONObject json = new JSONObject(entity);
+        assertEquals(FAILED.name(), json.get("status"));
+        assertEquals("failed_deactivate", json.get("message"));
+    }
 }

--- a/plugin-core/src/test/java/org/opennms/plugins/cloud/rest/CloudConfigRestServiceImplTest.java
+++ b/plugin-core/src/test/java/org/opennms/plugins/cloud/rest/CloudConfigRestServiceImplTest.java
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.opennms.plugins.cloud.config.ConfigurationManager.ConfigStatus.CONFIGURED;
+import static org.opennms.plugins.cloud.config.ConfigurationManager.ConfigStatus.DEACTIVATED;
 import static org.opennms.plugins.cloud.config.ConfigurationManager.ConfigStatus.FAILED;
 
 import javax.ws.rs.core.Response;
@@ -92,4 +93,28 @@ public class CloudConfigRestServiceImplTest {
         assertEquals(FAILED.name(), json.get("status"));
         assertEquals("ohoh", json.get("message"));
     }
+
+    Test
+    public void shouldPutDeactivateKey() {
+        when(cm.getStatus()).thenReturn(CONFIGURED);
+        Response response = new CloudConfigRestServiceImpl(cm)
+                .putDeactivateKey(API_KEY_JSON);
+        assertEquals(200, response.getStatus());
+        String entity = (String) response.getEntity();
+        JSONObject json = new JSONObject(entity);
+        assertEquals(DEACTIVATED.name(), json.get("status"));
+    }
+
+    // @Test
+    // public void shouldPutActivationKeyWithException() {
+    //     doThrow(new NullPointerException("ohoh")).when(cm).initConfiguration(anyString());
+    //     when(cm.getStatus()).thenReturn(FAILED);
+    //     Response response = new CloudConfigRestServiceImpl(cm)
+    //             .putActivationKey(API_KEY_JSON);
+    //     assertEquals(500, response.getStatus());
+    //     String entity = (String) response.getEntity();
+    //     JSONObject json = new JSONObject(entity);
+    //     assertEquals(FAILED.name(), json.get("status"));
+    //     assertEquals("ohoh", json.get("message"));
+    // }
 }

--- a/plugin-core/src/test/java/org/opennms/plugins/cloud/rest/CloudConfigRestServiceImplTest.java
+++ b/plugin-core/src/test/java/org/opennms/plugins/cloud/rest/CloudConfigRestServiceImplTest.java
@@ -94,7 +94,7 @@ public class CloudConfigRestServiceImplTest {
         assertEquals("ohoh", json.get("message"));
     }
 
-    Test
+    @Test
     public void shouldPutDeactivateKey() {
         when(cm.getStatus()).thenReturn(CONFIGURED);
         Response response = new CloudConfigRestServiceImpl(cm)


### PR DESCRIPTION
[CLOUD-2754](https://issues.opennms.org/browse/CLOUD-2754)
[CLOUD-2755](https://issues.opennms.org/browse/CLOUD-2755)

[Figma Diagram](https://www.figma.com/file/Bkg1XjlT0Ya0bsiBl6flxA/Cloud-Plugin?node-id=928%3A3072&t=SvWYZFbhp3W2qUKf-0)

### Initial (Non Activated Screen):

![image](https://user-images.githubusercontent.com/82829460/204644588-6268ef27-c512-4c8c-8dbe-b3991411fb6f.png)

### Screen during activation process:

![image](https://user-images.githubusercontent.com/82829460/204655585-8968fa3f-c4b6-4d89-9069-d08a94adfc1a.png)

### Post Activation display:

![image](https://user-images.githubusercontent.com/82829460/204649880-1600d99b-91f2-44b7-8e64-4ee45f77bbe2.png)

Deactivation confirm modal:

![image](https://user-images.githubusercontent.com/82829460/204649963-3fbe8343-0b25-438e-8f87-61c8d5ea5738.png)


