### PR TITLE
DC-475 - Change the default hostname for PAS for dp-prod

### DIFF
--- a/plugin-common/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/plugin-common/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -28,10 +28,10 @@
     <cm:property-placeholder id="tsaas-pocPluginProperties" persistent-id="org.opennms.plugins.cloud"
                              update-strategy="reload">
         <cm:default-properties>
-            <cm:property name="pas.tls.host" value="access.production.prod.dataservice.opennms.com"/>
+            <cm:property name="pas.tls.host" value="access.onms-dp-prod.production.prod.dataservice.opennms.com"/>
             <cm:property name="pas.tls.port" value="443"/>
             <cm:property name="pas.tls.security" value ="TLS" />
-            <cm:property name="pas.mtls.host" value="auth.access.production.prod.dataservice.opennms.com"/>
+            <cm:property name="pas.mtls.host" value="auth.access.onms-dp-prod.production.prod.dataservice.opennms.com"/>
             <cm:property name="pas.mtls.port" value="443"/>
             <cm:property name="pas.mtls.security" value ="MTLS" />
             <cm:property name="grpc.truststore" value="" />


### PR DESCRIPTION
The JIRA issue explains the reasoning, but for proper TLS termination and consistency with the other environments, we decided to change the PAS hostname at the cloud plugin level to point to the production environment (with the working FQDNs that have been deployed).