### PR TITLE
update build system for cloud plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,10 @@ jobs:
             if [[ -z "<< pipeline.git.tag >>" ]]; then
               MVN_OPTIONS="-Psnapshot"
             else
+              if [ "$(grep -c -- -SNAPSHOT pom.xml)" -gt 0 ]; then
+                echo 'ERROR: building from a tag, but pom.xml still contains a -SNAPSHOT version!'
+                exit 1
+              fi
               MVN_OPTIONS="-Prelease"
               BUILD_NUMBER=1
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,11 +24,19 @@ workflows:
       - build:
           context:
             - OpenNMS Build
+          filters:
+            tags:
+              only:
+                - /^v.*/
       - tests:
           requires:
             - build
           context:
             - SonarCloud
+          filters:
+            tags:
+              only:
+                - /^v.*/
       - deploy:
           context:
             - OSSRH Principal
@@ -38,7 +46,7 @@ workflows:
           filters:
             tags:
               only:
-                - /release-.*/
+                - /^v.*/
             branches:
               only:
                 - main
@@ -51,7 +59,7 @@ workflows:
           filters:
             tags:
               only:
-                - /release-.*/
+                - /^v.*/
             branches:
               only:
                 - main
@@ -64,7 +72,7 @@ workflows:
           filters:
             tags:
               only:
-                - /release-.*/
+                - /^v.*/
             branches:
               only:
                 - main
@@ -87,20 +95,18 @@ jobs:
             # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
       - run:
-          name: Compile source without tests
+          name: Compile source and RPMs without tests
           command: |
             mvn -version
-            # avoid release-[0-9].x go into release
-            if [[ ! << pipeline.git.branch >> =~ ^release-[0-9.]*$ ]]; then
+            BUILD_NUMBER="0.${CIRCLE_BUILD_NUM}"
+            # only build tags as a release
+            if [[ -z "<< pipeline.git.tag >>" ]]; then
               MVN_OPTIONS="-Psnapshot"
             else
               MVN_OPTIONS="-Prelease"
-              BUILD_NUMBER=$(echo '<< pipeline.git.branch >>' | sed -e 's/release-[^-]*-*//')
-              if [[ -z "$BUILD_NUMBER" ]]; then
-                BUILD_NUMBER=1
-              fi
-              MVN_OPTIONS="${MVN_OPTIONS} -DbuildNumber=${BUILD_NUMBER}"
+              BUILD_NUMBER=1
             fi
+            MVN_OPTIONS="${MVN_OPTIONS} -DbuildNumber=${BUILD_NUMBER}"
             mvn $MVN_OPTIONS -DskipITs=true -DskipTests=true -Dbuild.packages clean install
       - save_cache:
           paths:
@@ -156,7 +162,7 @@ jobs:
       - sign-packages/setup-env:
           skip_if_forked_pr: true
       - run:
-          name: Upload snapshot
+          name: Deploy to Maven
           command: |
             mvn -Prelease -s .circleci/.circleci.settings.xml -DskipTests -Dmaven.verify.skip=true -Dmaven.install.skip=true deploy
 
@@ -186,17 +192,15 @@ jobs:
       - run:
           name: Build Debian packages
           command: |
-            # avoid release-[0-9].x go into release
-            if [[ ! << pipeline.git.branch >> =~ ^release-[0-9.]*$ ]]; then
+            BUILD_NUMBER="0.${CIRCLE_BUILD_NUM}"
+            # only build tags as a release
+            if [[ -z "<< pipeline.git.tag >>" ]]; then
               MVN_OPTIONS="-Psnapshot"
             else
               MVN_OPTIONS="-Prelease"
-              BUILD_NUMBER=$(echo '<< pipeline.git.branch >>' | sed -e 's/release-[^-]*-*//')
-              if [[ -z "$BUILD_NUMBER" ]]; then
-                BUILD_NUMBER=1
-              fi
-              MVN_OPTIONS="${MVN_OPTIONS} -DbuildNumber=${BUILD_NUMBER}"
+              BUILD_NUMBER=1
             fi
+            MVN_OPTIONS="${MVN_OPTIONS} -DbuildNumber=${BUILD_NUMBER}"
             mvn install ${MVN_OPTIONS} --projects org.opennms.plugins.cloud.assembly:org.opennms.plugins.cloud.assembly.opennms.deb,org.opennms.plugins.cloud.assembly:org.opennms.plugins.cloud.assembly.sentinel.deb --also-make -DskipTests=true -Dbuild.packages
 
       - run:

--- a/.circleci/scripts/publish-cloudsmith.sh
+++ b/.circleci/scripts/publish-cloudsmith.sh
@@ -7,7 +7,7 @@ PROJECT="opennms"
 REPO=""
 
 if [ -n "${CIRCLE_TAG}" ]; then
-  REPO="stable"
+  REPO="common"
 else
   # only put release-1.0.0 into common, the release-1.x will still in common-testing
   case "${CIRCLE_BRANCH}" in
@@ -17,11 +17,8 @@ else
     main)
       REPO="common-testing"
       ;;
-    release-*x)
-      REPO="common-testing"
-      ;;
     release-*)
-      REPO="common"
+      REPO="common-testing"
       ;;
     *)
       echo "This branch is not eligible for deployment: ${CIRCLE_BRANCH}"

--- a/it-test/pom.xml
+++ b/it-test/pom.xml
@@ -11,6 +11,13 @@
   <name>OpenNMS :: Plugins :: Cloud Plugin :: Integration Test</name>
 
   <build>
+    <testResources>
+        <testResource>
+            <directory>src/test/resources</directory>
+            <filtering>true</filtering>
+        </testResource>
+    </testResources>
+
     <plugins>
       <plugin><!-- make fat jar to run MockCloud in container -->
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -229,26 +229,25 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M5</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.0.0-M5</version>
                 <configuration>
-                    <excludes>
-                        <exclude>**/*It.java</exclude>
-                    </excludes>
+                    <systemPropertyVariables>
+                        <pomVersion>${project.version}</pomVersion>
+                    </systemPropertyVariables>
+                    <includes>
+                        <include>**/*It.java</include>
+                    </includes>
                 </configuration>
                 <executions>
                     <execution>
-                        <id>integration-test</id>
                         <goals>
-                            <goal>test</goal>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
                         </goals>
-                        <phase>integration-test</phase>
-                        <configuration>
-                            <excludes>
-                                <exclude>none</exclude>
-                            </excludes>
-                            <includes>
-                                <include>**/*It.java</include>
-                            </includes>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
this PR does a few things:

* only build/perform release from tags
* set the build number to the job/build number from circleci unless it's a release
* fail if `-SNAPSHOT` is in poms but it's a release